### PR TITLE
feat(lightpanda): solve Akamai on a headless browser that is not Chrome

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,6 +1,15 @@
 {
   "plugins": [
-    "@semantic-release/commit-analyzer",
+    ["@semantic-release/commit-analyzer", {
+      "releaseRules": [
+        { "breaking": true, "release": "patch" },
+        { "revert": true, "release": "patch" },
+        { "type": "feat", "release": "patch" },
+        { "type": "fix", "release": "patch" },
+        { "type": "perf", "release": "patch" },
+        { "type": "refactor", "release": "patch" }
+      ]
+    }],
     "@semantic-release/release-notes-generator",
     ["@semantic-release/exec", {
       "verifyConditionsCmd": "make ci",

--- a/package.json
+++ b/package.json
@@ -23,8 +23,10 @@
     "grainger:axios": "node --env-file=.env src/datadome/grainger-axios.ts",
     "grainger:fetch": "node --use-env-proxy --env-file=.env src/datadome/grainger-fetch.ts",
     "grainger:browser": "node --env-file=.env src/datadome/grainger.ts",
+    "grainger:lightpanda": "node --env-file=.env src/datadome/grainger-lightpanda.ts",
     "idealista": "node --env-file=.env src/datadome/idealista.ts",
     "comcast": "node --env-file=.env src/akamai/comcast.ts",
+    "comcast:lightpanda": "node --env-file=.env src/akamai/comcast-lightpanda.ts",
     "ca-edd": "node --env-file=.env src/akamai/ca-edd.ts",
     "loadtest": "node --env-file=.env src/loadtest.ts",
     "prepare": "husky"

--- a/src/akamai/README.md
+++ b/src/akamai/README.md
@@ -84,6 +84,7 @@ the origin you actually need has to reach `~0~`.
 |---|---|
 | `comcast.ts` | solving across two origins during an OAuth redirect chain, up to the login form |
 | `ca-edd.ts` | the same, then an actual login — needs `username=` and `password=` in `.env` |
+| `comcast-lightpanda.ts` | the same target driven by **Lightpanda** instead of Chrome — see below |
 
 ```bash
 npm run comcast
@@ -92,6 +93,67 @@ npm run ca-edd
 ```
 
 Drop `--headless` to watch it happen.
+
+### lightpanda
+
+`comcast-lightpanda.ts` runs the same solve on [Lightpanda], a headless browser
+with no renderer — a ~70MB binary that starts in milliseconds. `solve()` needs
+no CDP session, so it drives a Lightpanda page unchanged:
+
+```bash
+curl -Lo lightpanda https://github.com/lightpanda-io/browser/releases/latest/download/lightpanda-aarch64-macos
+chmod +x lightpanda
+LIGHTPANDA_PATH=./lightpanda npm run comcast:lightpanda
+```
+
+It solves. `_abck` reaches `~0~` on round 5 — the same round Chrome takes:
+
+```
+[https://login.xfinity.com] Cookie update: round=5 rval=0 accepted=true _abck=~0~
+[https://login.xfinity.com] Cookie accepted (round 5)
+RESULT: SUCCESS - Akamai solved, reached /login
+```
+
+Four things had to be true, and each failed silently in a way that looked like
+something else:
+
+- **The connection is re-originated.** `src/lightpanda.ts` runs the browser
+  behind `src/mitm.ts`, a local proxy that terminates TLS and re-makes each
+  request with undici. That is also the only place the identity can be set:
+  Lightpanda's user agent cannot be changed from inside the browser, and
+  `context.newCDPSession()` — how `comcast.ts` overrides it — crashes
+  Playwright here.
+- **The identity has to be the profile the solver was told about**, not the
+  proxy's DataDome default. Telemetry claiming Chrome 146 under headers
+  claiming 149 is a mismatch, and `_abck` stays at `~-1~` however long you run.
+- **`fetchResponse` replaces `route.fetch`.** Playwright's route.fetch never
+  returns against Lightpanda — it runs in Playwright's request context, which
+  syncs cookies with the browser, and once that stops answering every later
+  route.fetch waits out its timeout, sensor script included. The MITM fetches
+  it instead, from the same address with the same headers.
+- **Cookies are applied by hand on that path.** `route.fulfill` carries one
+  `set-cookie` header and Akamai's document response sets four; lose `_abck`
+  and the session opens without the cookie the protocol advances. Akamai then
+  returns the *same* `_abck` to every submission and the rounds count up
+  forever. This is why each session now logs `cookies=[...]` by name: compare
+  it with a Chrome run and the missing one is right there.
+
+Two more that look like bugs and are not, both handled for you:
+
+- **`Target page, context or browser has been closed`, on everything at once.**
+  Lightpanda caps CDP messages at 1MB by default and drops the connection
+  rather than rejecting an oversized one. Playwright fulfills an intercepted
+  request by sending the whole body back over CDP, base64'd, so a single 1MB
+  analytics bundle ends the session. `start()` passes
+  `--cdp-max-message-size 32MB`.
+- **`page.goto` and `waitForLoadState` timing out.** The solver's 30s/15s
+  defaults are not enough for a script-heavy page under interception; they are
+  now the `navigationTimeout` and `loadStateTimeout` options.
+
+`_abck` only has to reach `~0~` on the origin you actually need — here
+login.xfinity.com. business.comcast.com stays at `~-1~` in a Chrome run too.
+
+[Lightpanda]: https://lightpanda.io
 
 ## gotchas
 

--- a/src/akamai/comcast-lightpanda.ts
+++ b/src/akamai/comcast-lightpanda.ts
@@ -1,0 +1,143 @@
+/**
+ * Run with:
+ *
+ * node --env-file=.env src/akamai/comcast-lightpanda.ts
+ *
+ * `comcast.ts` with **Lightpanda** in place of Chrome — a headless browser
+ * with no renderer, a ~70MB binary that starts in milliseconds. See
+ * `src/lightpanda.ts` for how it is started and what it does differently.
+ *
+ * This works — `_abck` reaches `~0~` on round 5, the same round Chrome takes:
+ *
+ *   [https://login.xfinity.com] Cookie update: round=5 rval=0 accepted=true
+ *   [https://login.xfinity.com] Cookie accepted (round 5)
+ *   RESULT: SUCCESS - Akamai solved, reached /login
+ *
+ * `solver.ts` needs no CDP session, so it drives a Lightpanda page unchanged.
+ * Four things had to be true first, and all four are set up below or in
+ * `src/lightpanda.ts`. Each one failed silently, and none of them looked like
+ * what it was:
+ *
+ *   1. **The traffic is re-originated** through `src/mitm.ts`, which also
+ *      supplies the identity — Lightpanda's user agent cannot be changed from
+ *      inside the browser, and `context.newCDPSession()`, which is how
+ *      `comcast.ts` overrides it, crashes Playwright here.
+ *   2. **The identity must be the one the Akamai solver models**
+ *      (`chrome-146-macos`), not the proxy's DataDome default. Telemetry that
+ *      says 146 under headers that say 149 is scored as a mismatch, and
+ *      `_abck` sits at `~-1~` for as many rounds as you care to give it.
+ *   3. **`fetchResponse`**, because Playwright's `route.fetch` never returns
+ *      against Lightpanda: it runs in Playwright's request context, which
+ *      syncs cookies with the browser, and once that stops answering every
+ *      later route.fetch waits out its timeout — the sensor script included,
+ *      so no session ever opens.
+ *   4. **Cookies applied by hand** on that path, which `solver.ts` now does.
+ *      `route.fulfill` carries one `set-cookie` header, and Akamai's document
+ *      response sets four. Losing `_abck` starts the session without the
+ *      cookie the whole protocol advances: Akamai then returns the *same*
+ *      `_abck` to every submission, and the rounds count up forever. The
+ *      `cookies=[...]` line each session logs is what makes this visible —
+ *      compare it against a Chrome run and the missing name is right there.
+ *
+ * Two more that look like bugs and are not, both handled in
+ * `src/lightpanda.ts` and below: Lightpanda's 1MB default CDP message cap
+ * (one 1MB analytics bundle silently drops the connection), and the solver's
+ * 30s/15s navigation defaults, which a page this heavy overruns.
+ */
+import { solve } from '#src/akamai/solver.js';
+import { outerHtml, start } from '#src/lightpanda.js';
+
+const url = 'https://business.comcast.com/account/';
+const solverHost = process.env['host'];
+const proxy = process.env['proxy'];
+const solverApiKey = process.env['solver_api_key'];
+
+if (!solverHost) throw new Error('set host= in .env');
+if (!proxy) throw new Error('set proxy= in .env');
+
+const solverUrl = `ws://${solverHost}:3000/akamai/session`;
+const timeout = Number(process.env['AKAMAI_TIMEOUT_MS'] ?? 120_000);
+
+const log = (msg: string, ...extra: unknown[]): void =>
+  console.log(`[${new Date().toISOString()}] ${msg}`, ...extra);
+
+/**
+ * What the MITM proxy claims upstream. This has to be the browser the *Akamai*
+ * solver models — `profileId: 'chrome-146-macos'`, the same identity
+ * `comcast.ts` installs with `Emulation.setUserAgentOverride`. The proxy's
+ * default is the DataDome profile, which is a different Chrome: send that and
+ * the telemetry says 146 while the headers say 149, and `_abck` sits at `~-1~`
+ * however many rounds you give it.
+ */
+const IDENTITY = {
+  'sec-ch-ua':
+    '"Chromium";v="146", "Not-A.Brand";v="24", "Google Chrome";v="146"',
+  'sec-ch-ua-mobile': '?0',
+  'sec-ch-ua-platform': '"macOS"',
+  'user-agent':
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36',
+};
+
+const session = await start({ identity: IDENTITY, log, proxy });
+let exitCode = 0;
+
+process.once('SIGINT', () => {
+  log('Caught SIGINT');
+  void session.stop().then(() => process.exit(0));
+});
+process.once('SIGTERM', () => {
+  log('Caught SIGTERM');
+  void session.stop().then(() => process.exit(0));
+});
+
+if (!session.mitm) throw new Error('the MITM proxy did not start');
+
+try {
+  await solve(session.page, {
+    // The one change that makes this run at all. Playwright's `route.fetch`
+    // never returns against Lightpanda, so the sensor script is never
+    // captured and no session ever opens. The MITM proxy in front of the
+    // browser can fetch it instead — same dispatcher, same exit IP, same
+    // Chrome headers as everything else the page sends.
+    fetchResponse: session.mitm.fetch,
+    // Lightpanda is slower than Chrome under interception — every request on
+    // the page is refetched through the proxy, and comcast.com pulls a lot of
+    // script — so the defaults (30s/15s) run out before the page settles.
+    loadStateTimeout: 60_000,
+    navigationTimeout: 90_000,
+    proxy,
+    ...(solverApiKey ? { solverApiKey } : {}),
+    solverUrl,
+    timeout,
+    url,
+  });
+
+  // The goal is a real page rather than Akamai's block — not a completed
+  // login, which would need credentials this repo does not carry.
+  log(`Final URL: ${session.page.url()}`);
+  const html = await outerHtml(session.page.mainFrame());
+  const denied = /access denied/i.test(html);
+  if (denied) {
+    exitCode = 2;
+    log('RESULT: FAIL - Access Denied');
+  } else {
+    log(
+      `RESULT: SUCCESS - Akamai solved, reached ${new URL(session.page.url()).pathname}`
+    );
+  }
+} catch (error) {
+  exitCode = 1;
+  log(`RESULT: FAIL - ${(error as Error).message}`);
+  // The two failures worth telling apart, because they look identical from
+  // here and have nothing to do with each other.
+  log(
+    'If the rounds ran but never reached ~0~, check the `cookies=[...]` line ' +
+      'for `_abck` and the identity above against the solver profile. If no ' +
+      'session opened at all, the sensor script was never captured — look ' +
+      'for a fetch that did not return.'
+  );
+} finally {
+  await session.stop();
+}
+
+process.exit(exitCode);

--- a/src/akamai/solver.ts
+++ b/src/akamai/solver.ts
@@ -37,6 +37,34 @@ import type { BrowserContext, Frame, Page, Route } from 'playwright-core';
 import { WebSocket } from 'undici';
 
 export type SolveOptions = {
+  /**
+   * Fetch intercepted requests with this instead of Playwright's
+   * `route.fetch`. Only needed for browsers where route.fetch is unreliable —
+   * `src/mitm.ts` exposes exactly this shape, and
+   * `src/akamai/comcast-lightpanda.ts` passes it. Whatever you give it must
+   * come from the same address the browser uses, or the telemetry will be
+   * scored against the wrong client.
+   */
+  fetchResponse?: (
+    // eslint-disable-next-line no-unused-vars -- function-type parameters
+    request: {
+      body?: string;
+      headers: Record<string, string>;
+      method: string;
+      url: string;
+    }
+  ) => Promise<Fetched>;
+  /**
+   * How long a frame gets to reach `domcontentloaded` after it navigates,
+   * before we give up on reading the sensor script out of it. Default 15s.
+   */
+  loadStateTimeout?: number;
+  /**
+   * How long the opening navigation gets. Default 30s. Every request on the
+   * page is intercepted and refetched, so a script-heavy target behind a slow
+   * proxy — or a browser slower than Chrome — can need more.
+   */
+  navigationTimeout?: number;
   proxy?: string;
   /**
    * Sent as `x-api-key` on the WebSocket upgrade. Required when the solver
@@ -50,6 +78,15 @@ export type SolveOptions = {
 };
 
 type CookieRecord = Record<string, string>;
+
+/** A response, however it was fetched. */
+type Fetched = {
+  body: string;
+  headers: Record<string, string>;
+  /** Each `set-cookie` separately; a joined string cannot be parsed back. */
+  setCookie?: string[];
+  status: number;
+};
 type SolverMessage = {
   accepted?: boolean;
   body?: string;
@@ -141,7 +178,16 @@ const PROFILE = {
 };
 
 export async function solve(page: Page, opts: SolveOptions): Promise<void> {
-  const { proxy, solverApiKey, solverUrl, timeout = 120000, url } = opts;
+  const {
+    fetchResponse,
+    loadStateTimeout = 15000,
+    navigationTimeout = 30000,
+    proxy,
+    solverApiKey,
+    solverUrl,
+    timeout = 120000,
+    url,
+  } = opts;
   const context: BrowserContext = page.context();
   const capturedDocs = new Map<string, { html: string; url: string }>();
   const capturedScripts = new Map<string, string>();
@@ -283,6 +329,26 @@ export async function solve(page: Page, opts: SolveOptions): Promise<void> {
                 );
                 resultStatus = result.status;
                 resultBody = result.body;
+              } else if (fetchResponse) {
+                // No frame for this origin, but we have a fetcher that shares
+                // the browser's address. Prefer it over context.request:
+                // Playwright's request context is a separate client, and on a
+                // CDP-attached browser it does not even use the browser's
+                // proxy — telemetry posted from a different IP than the page
+                // is scored as a different visitor and never accepted.
+                const resp = await fetchResponse({
+                  body: body ?? '',
+                  headers: {
+                    ...xhrHeaders,
+                    Origin: scriptOrigin,
+                    Referer: data.url,
+                  },
+                  method: method ?? 'POST',
+                  url: subUrl ?? '',
+                });
+                await applyCookies(subUrl ?? '', resp.setCookie);
+                resultStatus = resp.status;
+                resultBody = resp.body;
               } else {
                 const submitUrl = subUrl ?? '';
                 const submitMethod = method ?? 'POST';
@@ -356,7 +422,7 @@ export async function solve(page: Page, opts: SolveOptions): Promise<void> {
       const cookies = cookiesToRecord(await context.cookies(cookieUrl));
       const sanitizedHtml = stripScripts(html);
       log(
-        `[${origin}] Captured: script=${script.length}b html=${sanitizedHtml.length}b cookies=${Object.keys(cookies).length}`
+        `[${origin}] Captured: script=${script.length}b html=${sanitizedHtml.length}b cookies=[${Object.keys(cookies).sort().join(',')}]`
       );
       startSession(
         origin,
@@ -370,14 +436,41 @@ export async function solve(page: Page, opts: SolveOptions): Promise<void> {
     // silently, leaving the Akamai script uncaptured and the solve session
     // never started (hanging until the caller's outer timeout). Retry once
     // and log any failure so it's visible instead of a silent 120s hang.
+    //
+    // `fetchResponse` replaces route.fetch entirely when the caller supplies
+    // one, because against some browsers route.fetch is the thing that fails:
+    // it runs in Playwright's request context, which syncs cookies with the
+    // browser, and on Lightpanda that stops answering — after which every
+    // route.fetch waits out its timeout. See comcast-lightpanda.ts.
     const fetchWithRetry = async (
       route: Route,
       attempts = 2
-    ): Promise<Awaited<ReturnType<Route['fetch']>>> => {
+    ): Promise<Fetched> => {
       let lastErr: unknown;
       for (let i = 0; i < attempts; i++) {
         try {
-          return await route.fetch({ maxRedirects: 0 });
+          if (fetchResponse) {
+            const req = route.request();
+            const postData = req.postData();
+            const response = await fetchResponse({
+              ...(postData === null ? {} : { body: postData }),
+              headers: await req.allHeaders(),
+              method: req.method(),
+              url: req.url(),
+            });
+            return {
+              body: response.body,
+              headers: response.headers,
+              ...(response.setCookie ? { setCookie: response.setCookie } : {}),
+              status: response.status,
+            };
+          }
+          const resp = await route.fetch({ maxRedirects: 0 });
+          return {
+            body: await resp.text(),
+            headers: resp.headers(),
+            status: resp.status(),
+          };
         } catch (e) {
           lastErr = e;
         }
@@ -385,21 +478,91 @@ export async function solve(page: Page, opts: SolveOptions): Promise<void> {
       throw lastErr;
     };
 
+    /**
+     * Put a response's cookies in the browser's jar ourselves.
+     *
+     * `route.fulfill` takes one header map, so it can carry exactly one
+     * `set-cookie` — a response that sets four (Akamai sets `_abck`, `bm_sz`,
+     * `ak_bmsc`, `bm_sv`) loses three of them, and if `_abck` is one of the
+     * lost ones the session starts without the very cookie the protocol
+     * advances. That failure is invisible: every round returns the same
+     * `_abck` and `rval` never leaves -1.
+     *
+     * Playwright applies cookies itself when `route.fetch` did the fetching,
+     * so this only runs on the `fetchResponse` path.
+     */
+    const applyCookies = async (
+      url: string,
+      setCookie: string[] | undefined
+    ): Promise<void> => {
+      if (!setCookie || setCookie.length === 0) return;
+      const { hostname } = new URL(url);
+      const cookies = setCookie.flatMap((header) => {
+        const [pair, ...attributes] = header.split(';');
+        const index = pair?.indexOf('=') ?? -1;
+        if (!pair || index < 1) return [];
+        const attribute = (name: string): string | undefined =>
+          attributes
+            .map((a) => a.trim())
+            .find((a) => a.toLowerCase().startsWith(`${name}=`))
+            ?.slice(name.length + 1);
+        const expires = attribute('expires');
+        const maxAge = attribute('max-age');
+        const seconds = maxAge === undefined ? NaN : Number(maxAge);
+        const expiresAt = Number.isFinite(seconds)
+          ? Date.now() / 1000 + seconds
+          : expires
+            ? Date.parse(expires) / 1000
+            : NaN;
+        return [
+          {
+            domain: attribute('domain') ?? hostname,
+            ...(Number.isFinite(expiresAt) ? { expires: expiresAt } : {}),
+            httpOnly: attributes.some(
+              (a) => a.trim().toLowerCase() === 'httponly'
+            ),
+            name: pair.slice(0, index).trim(),
+            path: attribute('path') ?? '/',
+            secure: attributes.some((a) => a.trim().toLowerCase() === 'secure'),
+            value: pair.slice(index + 1).trim(),
+          },
+        ];
+      });
+      if (cookies.length > 0) await context.addCookies(cookies);
+    };
+
+    /** Pass a fetched response back to the page, framing headers stripped. */
+    const fulfillFetched = (
+      route: Route,
+      fetched: Fetched,
+      body = fetched.body
+    ): Promise<void> => {
+      const headers = { ...fetched.headers };
+      // The body we hold is decoded, so the original framing would be a lie,
+      // and the cookies went into the jar through applyCookies instead.
+      delete headers['content-encoding'];
+      delete headers['content-length'];
+      delete headers['set-cookie'];
+      return route.fulfill({ body, headers, status: fetched.status });
+    };
+
     const routeHandler = async (route: Route) => {
       const req = route.request();
       if (req.resourceType() === 'document') {
         try {
           const resp = await fetchWithRetry(route);
-          const ct = resp.headers()['content-type'] ?? '';
-          if (resp.ok() && ct.includes('text/html')) {
-            const html = await resp.text();
+          const ct = resp.headers['content-type'] ?? '';
+          if (resp.status < 400 && ct.includes('text/html')) {
             capturedDocs.set(new URL(req.url()).origin, {
-              html,
+              html: resp.body,
               url: req.url(),
             });
-            return await route.fulfill({ body: html, response: resp });
           }
-          return await route.fulfill({ response: resp });
+          // Release the route before touching the cookie jar: while a request
+          // is paused, `addCookies` waits behind it on Lightpanda and the
+          // navigation never completes.
+          await fulfillFetched(route, resp);
+          return await applyCookies(req.url(), resp.setCookie);
         } catch (e) {
           log(
             `Document fetch failed for ${req.url()}: ${(e as Error).message}`
@@ -409,9 +572,19 @@ export async function solve(page: Page, opts: SolveOptions): Promise<void> {
       if (req.resourceType() === 'script') {
         try {
           const resp = await fetchWithRetry(route);
-          const body = await resp.text();
+          const body = resp.body;
           capturedScripts.set(req.url(), body);
           if (isLikelyAkamaiScriptUrl(req.url())) {
+            // The page gets a stub: the real sensor must not run, or it posts
+            // its own telemetry alongside the solver's.
+            await route.fulfill({
+              body: '/* blocked */',
+              contentType: 'application/javascript',
+              status: 200,
+            });
+            // Cookies first, then the session — `init` sends the jar, and a
+            // session that opens without the current `_abck` never advances.
+            await applyCookies(req.url(), resp.setCookie);
             const scriptOrigin = new URL(req.url()).origin;
             const doc = capturedDocs.get(scriptOrigin);
             if (doc && !sessions.has(scriptOrigin))
@@ -423,13 +596,10 @@ export async function solve(page: Page, opts: SolveOptions): Promise<void> {
                 doc.html,
                 null
               );
-            return await route.fulfill({
-              body: '/* blocked */',
-              contentType: 'application/javascript',
-              status: 200,
-            });
+            return;
           }
-          return await route.fulfill({ body, response: resp });
+          await fulfillFetched(route, resp, body);
+          return await applyCookies(req.url(), resp.setCookie);
         } catch (e) {
           log(`Script fetch failed for ${req.url()}: ${(e as Error).message}`);
         }
@@ -513,7 +683,9 @@ export async function solve(page: Page, opts: SolveOptions): Promise<void> {
       }
 
       try {
-        await frame.waitForLoadState('domcontentloaded', { timeout: 15000 });
+        await frame.waitForLoadState('domcontentloaded', {
+          timeout: loadStateTimeout,
+        });
         await processFrame(frame);
       } catch (e) {
         log(`Navigation handling error: ${(e as Error).message}`);
@@ -524,7 +696,7 @@ export async function solve(page: Page, opts: SolveOptions): Promise<void> {
       .then(() => {
         page.on('framenavigated', navHandler);
         return page.goto(url, {
-          timeout: 30000,
+          timeout: navigationTimeout,
           waitUntil: 'domcontentloaded',
         });
       })

--- a/src/datadome/README.md
+++ b/src/datadome/README.md
@@ -149,11 +149,22 @@ details of that proxy were found here:
 - Lightpanda sends six headers and no `sec-fetch-*`. Without them grainger.com
   serves its own error page instead of the real one.
 
-**Status:** it reaches the submission and DataDome hands back a clearance
-cookie, but that cookie is currently refused on first use — and so is one
-earned by submitting the same prepared payload from Node with the canonical
-`submissionHeaders()`. That points at the solver's DataDome path rather than
-anything in this file, and it is being fixed. Re-run this when it is.
+**Status:** it works, but not on every attempt. A verified attempt returns the
+real page and DataDome rotates the cookie:
+
+```
+clearance cookie: datadome=QTlff_rUpD_JXTy6VJjnQ0wA9hB7akP68m1D2t678Gh_…
+verifying against the target
+  <- HTTP 200 (489743 bytes) "Grainger Industrial Supply - MRO Products…"
+```
+
+About one attempt in four gets there; the others earn a cookie that is refused
+on first use and come back as a fresh `rt=c t=fe`. With the three attempts the
+runner makes, a run succeeds roughly six times in ten. `grainger-undici.ts` on
+the same proxy in the same minute verifies first time, every time — so what is
+borderline is the solve computed from a Lightpanda page, not the solver, the
+proxy, or the IP. Retry rather than expect it; a failed attempt costs about
+seven seconds.
 
 See `src/lightpanda.ts` for the three differences that bite immediately (never
 reuse the starting page, `newCDPSession` crashes Playwright, `content()` never

--- a/src/datadome/README.md
+++ b/src/datadome/README.md
@@ -94,6 +94,7 @@ HTTP flow is far cheaper.
 | `grainger-axios.ts` | the same flow with **axios** and a cookie jar |
 | `grainger-fetch.ts` | the same flow with **Node's built-in fetch** and no dependencies |
 | `grainger.ts` | the same target through the browser bridge |
+| `grainger-lightpanda.ts` | the flow driven by **Lightpanda** instead of Chrome — see below |
 | `idealista.ts` | an interstitial that escalates to a captcha |
 | `http-utils.ts` | request building and response parsing the three HTTP versions share |
 | `profile.ts` | the browser identity and DataDome endpoints, shared with `solver.ts` |
@@ -114,6 +115,51 @@ npm run grainger:fetch    # no dependencies
 node --env-file=.env src/datadome/grainger-undici.ts --url=https://www.idealista.com/
 node --env-file=.env src/datadome/idealista.ts --headless
 ```
+
+### lightpanda
+
+`grainger-lightpanda.ts` swaps Chrome for [Lightpanda], a headless browser with
+no renderer — a ~70MB binary that starts in milliseconds and holds a page in a
+few MB. Get it, or point `LIGHTPANDA_PATH=` at a copy you already have:
+
+```bash
+curl -Lo lightpanda https://github.com/lightpanda-io/browser/releases/latest/download/lightpanda-aarch64-macos
+chmod +x lightpanda
+LIGHTPANDA_PATH=./lightpanda npm run grainger:lightpanda
+```
+
+**Lightpanda cannot reach DataDome on its own.** Point it straight at a proxy
+and DataDome answers `rt:"c"` with `t:"bv"` — a banned visitor — before a line
+of JavaScript runs, where the same proxy IP a second later gets a plain
+`t:"fe"` from `grainger-undici.ts`. It is not the user agent: undici sending
+`User-Agent: Lightpanda/1.0` over that proxy still gets `t:"fe"`. It is the
+connection, and nothing inside the browser can change it — `--user-agent`
+rejects any value containing "Mozilla", and `Emulation.setUserAgentOverride` is
+ignored on the wire.
+
+So `src/lightpanda.ts` puts `src/mitm.ts` in front of it: a local proxy that
+terminates TLS and re-makes each request with undici, the client the
+browser-free examples already use. With that the ban is gone — grainger serves
+an ordinary interstitial and the solve comes back in a second or two. Two
+details of that proxy were found here:
+
+- a request with **no `accept-encoding`** gets a captcha where the same request
+  with one gets an interstitial. `undici.request` sends none, `undici.fetch`
+  does, so the proxy uses `fetch`.
+- Lightpanda sends six headers and no `sec-fetch-*`. Without them grainger.com
+  serves its own error page instead of the real one.
+
+**Status:** it reaches the submission and DataDome hands back a clearance
+cookie, but that cookie is currently refused on first use — and so is one
+earned by submitting the same prepared payload from Node with the canonical
+`submissionHeaders()`. That points at the solver's DataDome path rather than
+anything in this file, and it is being fixed. Re-run this when it is.
+
+See `src/lightpanda.ts` for the three differences that bite immediately (never
+reuse the starting page, `newCDPSession` crashes Playwright, `content()` never
+returns).
+
+[Lightpanda]: https://lightpanda.io
 
 There is a shell version too, `dev-resources/curl`, which is the same flow in
 curl and jq. It is the clearest place to see the raw HTTP, and it doubles as a

--- a/src/datadome/grainger-lightpanda.ts
+++ b/src/datadome/grainger-lightpanda.ts
@@ -33,11 +33,24 @@
  *
  * ## status
  *
- * End to end this reaches the submission, and DataDome hands back a clearance
- * cookie — but the cookie is currently refused on first use, and so is one
- * earned by submitting the same prepared payload from Node with the canonical
- * `submissionHeaders()`. That points at the solver's DataDome path rather than
- * anything here; it is being fixed. Everything in this file is ready for it.
+ * This works, but not every time. A verified attempt returns the real page and
+ * DataDome rotates the cookie, which is the whole flow:
+ *
+ *   clearance cookie: datadome=QTlff_rUpD_JXTy6VJjnQ0wA9hB7akP68m1D2t678Gh_…
+ *   verifying against the target
+ *     <- HTTP 200 (489743 bytes) "Grainger Industrial Supply - MRO Products…"
+ *
+ * Roughly one attempt in four gets that far; the rest earn a cookie that is
+ * refused on first use and come back as a fresh `rt=c t=fe`. The three
+ * attempts `run()` makes turn that into a run that succeeds about six times in
+ * ten. `grainger-undici.ts` on the same proxy, the same minute, verifies on
+ * the first attempt every time — so this is the browser, not the solver and
+ * not the IP. The cookie is what DataDome scores it as: a solve computed from
+ * a Lightpanda page is evidently borderline, and it falls on either side of
+ * the line from one attempt to the next.
+ *
+ * Retry rather than expect it. Nothing below needs changing to make an
+ * attempt work; a failed one costs about seven seconds.
  *
  * ## what it does
  *

--- a/src/datadome/grainger-lightpanda.ts
+++ b/src/datadome/grainger-lightpanda.ts
@@ -1,0 +1,284 @@
+/**
+ * Run with:
+ *
+ * node --env-file=.env src/datadome/grainger-lightpanda.ts
+ * node --env-file=.env src/datadome/grainger-lightpanda.ts --url=https://www.idealista.com/
+ *
+ * The DataDome flow driven by **Lightpanda** instead of Chrome — a headless
+ * browser with no renderer, a ~70MB binary that starts in milliseconds. See
+ * `src/lightpanda.ts` for how it is started and what it does differently.
+ *
+ * ## Lightpanda cannot reach DataDome on its own
+ *
+ * Point it straight at a proxy and DataDome answers with `rt:"c"` and
+ * **`t:"bv"`** — a banned visitor — before a line of JavaScript has run, where
+ * the same proxy IP a second later gets a plain `t:"fe"` from
+ * `grainger-undici.ts`. It is not the user agent: undici sending
+ * `User-Agent: Lightpanda/1.0` over that proxy still gets `t:"fe"`. It is the
+ * connection, and nothing inside the browser can change it — `--user-agent`
+ * rejects any value containing "Mozilla" and `Emulation.setUserAgentOverride`
+ * is ignored on the wire.
+ *
+ * So `src/lightpanda.ts` puts `src/mitm.ts` in front of it: a local proxy that
+ * terminates TLS and re-makes each request with undici, which is the client
+ * the browser-free examples already use. With that in place the ban is gone —
+ * grainger serves a normal interstitial and the solve comes back in a second
+ * or two. Two details of that proxy were found here and matter:
+ *
+ *   - a request with **no `accept-encoding`** gets a captcha where the same
+ *     request with one gets an interstitial. `undici.request` sends none;
+ *     `undici.fetch` does, so the proxy uses `fetch`.
+ *   - Lightpanda sends six headers and no `sec-fetch-*`. Without them
+ *     grainger.com serves its own error page instead of the real one.
+ *
+ * ## status
+ *
+ * End to end this reaches the submission, and DataDome hands back a clearance
+ * cookie — but the cookie is currently refused on first use, and so is one
+ * earned by submitting the same prepared payload from Node with the canonical
+ * `submissionHeaders()`. That points at the solver's DataDome path rather than
+ * anything here; it is being fixed. Everything in this file is ready for it.
+ *
+ * ## what it does
+ *
+ * Not `solver.ts`. The browser bridge opens a CDP session per page, which
+ * crashes on Lightpanda, so this is the **HTTP flow** with the browser doing
+ * the parts that need a browser:
+ *
+ *   1. navigate to the target, and be challenged
+ *   2. read `var dd = {...}` and the challenge iframe out of the live DOM
+ *   3. POST them to `/dd/solve` from Node — direct, not through the proxy
+ *   4. submit from *inside the challenge frame* with `fetch()`, so it carries
+ *      the browser's own connection, headers and cookies
+ *   5. set the clearance cookie and navigate again
+ *
+ * Step 4 is the part worth keeping whatever the browser: DataDome binds the
+ * cookie to the IP that submitted it, and every request Lightpanda makes goes
+ * through the proxy it was started with.
+ */
+import { setTimeout as sleep } from 'node:timers/promises';
+
+import type { Frame, Page } from 'playwright-core';
+
+import {
+  challengeDocumentUrl,
+  checkPreparedSubmission,
+  type Context,
+  log,
+  type Outcome,
+  pageTitle,
+  parseBlockPage,
+  type PreparedSubmission,
+  readClearanceCookie,
+  run,
+  solveEndpoint,
+  solveRequestBody,
+  TIMEOUT_MS,
+} from '#src/datadome/http-utils.js';
+import { GEO_HOST } from '#src/datadome/profile.js';
+import { outerHtml, start } from '#src/lightpanda.js';
+
+const CHALLENGE_FRAME_TIMEOUT_MS = 20_000;
+const NAVIGATION_TIMEOUT_MS = 45_000;
+
+/**
+ * DataDome's `c.js` injects the challenge in an iframe. Waiting for the frame
+ * is cheaper than rebuilding its URL, and it proves the page's script ran.
+ */
+const waitForChallengeFrame = async (
+  page: Page
+): Promise<Frame | undefined> => {
+  const deadline = Date.now() + CHALLENGE_FRAME_TIMEOUT_MS;
+  for (;;) {
+    const frame = page
+      .frames()
+      .find((candidate) => candidate.url().includes(GEO_HOST));
+    if (frame) return frame;
+    if (Date.now() > deadline) return undefined;
+    await sleep(250);
+  }
+};
+
+const attempt = async ({
+  proxy,
+  solverApiKey,
+  solverUrl,
+  targetUrl,
+}: Context): Promise<null | Outcome> => {
+  // The solver reads the challenge document, and it has to be the bytes
+  // DataDome served — not the DOM after Lightpanda has parsed and run it, which
+  // is a different (and much larger) document. The MITM proxy sees the
+  // original, so take it from there.
+  const documents = new Map<string, string>();
+  const { context, page, stop } = await start({
+    log: (message) => log(message),
+    onResponse: ({ body, url }) => {
+      if (url.includes(GEO_HOST) && /\/(?:captcha|interstitial)\//.test(url)) {
+        documents.set(url, body);
+      }
+    },
+    proxy,
+  });
+  try {
+    // 1. Trip the challenge.
+    log(`GET ${targetUrl}`);
+    const blocked = await page.goto(targetUrl, {
+      timeout: NAVIGATION_TIMEOUT_MS,
+      waitUntil: 'commit',
+    });
+    const blockedHtml = await outerHtml(page.mainFrame());
+    log(`  <- HTTP ${blocked?.status()} (${blockedHtml.length} bytes)`);
+
+    const dd = parseBlockPage(blockedHtml);
+    if (!dd) {
+      log('  no DataDome challenge — the request went straight through');
+      return null;
+    }
+    log(
+      `  challenge: ${dd.rt === 'c' ? 'captcha' : 'interstitial'} t=${dd.t ?? '?'} cid=${dd.cid}`
+    );
+    // `bv` is a banned visitor. There is no solve for it — DataDome has already
+    // decided about this client, and the solver will reject the request. Say
+    // that here, where the reason is still visible.
+    if (dd.t === 'bv') {
+      throw new Error(
+        'DataDome served t="bv" (banned visitor) — it rejected Lightpanda on ' +
+          'sight. The user agent is Lightpanda/1.0 and the TLS fingerprint is ' +
+          "Lightpanda's; nothing downstream can recover from that. Compare " +
+          'grainger-undici.ts on the same proxy, which gets t="fe".'
+      );
+    }
+
+    // 2. Take the challenge document from the load the page already did — the
+    //    frame for its origin, the proxy for its bytes.
+    const frame = await waitForChallengeFrame(page);
+    if (!frame) {
+      throw new Error(
+        `the challenge iframe never loaded — lightpanda ran the block page but not ${GEO_HOST}`
+      );
+    }
+    const documentUrl = frame.url();
+    const documentHtml = documents.get(documentUrl);
+    if (!documentHtml) {
+      throw new Error(
+        `the proxy never saw ${documentUrl} — it captured ${documents.size} challenge documents`
+      );
+    }
+    log(`  challenge document: ${documentHtml.length} bytes`);
+    // The URL c.js built should match what the HTTP examples reconstruct. A
+    // divergence means the protocol moved; worth saying, not worth stopping.
+    const expected = new URL(challengeDocumentUrl(dd, targetUrl)).pathname;
+    const actual = new URL(documentUrl).pathname;
+    if (expected !== actual) {
+      log(
+        `  note: expected the challenge at ${expected}, frame is at ${actual}`
+      );
+    }
+
+    // 3. Ask xhr.dev to build the submission — but not to send it.
+    log('POST /dd/solve');
+    const solve = await fetch(solveEndpoint(solverUrl), {
+      body: JSON.stringify(
+        solveRequestBody({ dd, documentHtml, documentUrl, proxy, targetUrl })
+      ),
+      headers: {
+        'content-type': 'application/json',
+        ...(solverApiKey ? { 'x-api-key': solverApiKey } : {}),
+      },
+      method: 'POST',
+      signal: AbortSignal.timeout(TIMEOUT_MS),
+    });
+    if (!solve.ok) {
+      throw new Error(
+        `solver returned HTTP ${solve.status}: ${(await solve.text()).slice(0, 300)}`
+      );
+    }
+    const prepared = checkPreparedSubmission(
+      (await solve.json()) as PreparedSubmission
+    );
+    log('  <- prepared submission');
+
+    // 4. Submit from inside the challenge frame. Same origin as the endpoint,
+    //    so the browser sets origin, referer and sec-fetch-* itself and sends
+    //    the cookies it already holds — over the proxied connection this page
+    //    is already using, which is the address the cookie will be bound to.
+    log(
+      `${prepared.body ? 'POST' : 'GET'} submission from the challenge frame`
+    );
+    const submitted = await frame.evaluate(
+      async ({ body, url }: { body?: string; url: string }) => {
+        const response = await fetch(url, {
+          ...(body === undefined
+            ? { method: 'GET' }
+            : {
+                body,
+                headers: {
+                  'content-type':
+                    'application/x-www-form-urlencoded; charset=UTF-8',
+                },
+                method: 'POST',
+              }),
+          credentials: 'include',
+        });
+        return { body: await response.text(), status: response.status };
+      },
+      {
+        ...(prepared.body === undefined ? {} : { body: prepared.body }),
+        url: prepared.url,
+      }
+    );
+    log(`  <- HTTP ${submitted.status}`);
+    const cookie = readClearanceCookie(submitted.body);
+    log(`clearance cookie: datadome=${cookie}`);
+
+    // 5. Put the cookie in the jar, replacing rather than adding to it. The
+    //    block response already left a pre-solve `datadome` cookie there; send
+    //    both and the stale one wins, which looks exactly like a failed solve.
+    //    `/captcha/check` answers from geo.captcha-delivery.com with
+    //    `Domain=.grainger.com`, so the browser drops it as a cross-site
+    //    cookie and we have to place it by hand.
+    const { hostname } = new URL(targetUrl);
+    const before = await context.cookies(targetUrl);
+    log(
+      `  cookie jar before: ${before.map((c) => `${c.name}@${c.domain}`).join(', ') || 'empty'}`
+    );
+    await context.clearCookies({ name: 'datadome' });
+    await context.addCookies([
+      {
+        domain: `.${hostname.replace(/^www\./, '')}`,
+        name: 'datadome',
+        path: '/',
+        secure: true,
+        value: cookie,
+      },
+    ]);
+    const after = await context.cookies(targetUrl);
+    log(
+      `  cookie jar after: ${after.map((c) => `${c.name}@${c.domain}`).join(', ') || 'empty'}`
+    );
+
+    // 6. Prove it: the navigation that 403'd should now return the real page.
+    log('verifying against the target');
+    const verified = await page.goto(targetUrl, {
+      timeout: NAVIGATION_TIMEOUT_MS,
+      waitUntil: 'commit',
+    });
+    const html = await outerHtml(page.mainFrame());
+    const title = pageTitle(html);
+    const status = verified?.status() ?? 0;
+    log(`  <- HTTP ${status} (${html.length} bytes) "${title ?? ''}"`);
+    if (status !== 200) {
+      // A second challenge here is not the same failure as the first one. Say
+      // what kind it is: a fresh `fe` means the cookie was not honoured, `bv`
+      // means the client itself was rejected on this request.
+      const again = parseBlockPage(html);
+      if (again) log(`  challenged again: rt=${again.rt} t=${again.t ?? '?'}`);
+    }
+
+    return { cookie, status, title };
+  } finally {
+    await stop();
+  }
+};
+
+await run(attempt);

--- a/src/lightpanda.ts
+++ b/src/lightpanda.ts
@@ -1,0 +1,247 @@
+/**
+ * This is a helper library, not a script. It starts a Lightpanda process and
+ * hands back a Playwright page attached to it, for
+ * `src/datadome/grainger-lightpanda.ts` and `src/akamai/comcast-lightpanda.ts`.
+ *
+ * Lightpanda (<https://lightpanda.io>) is a headless browser that speaks CDP
+ * and runs V8, with no renderer and no graphics stack — a ~70MB binary that
+ * starts in milliseconds. Playwright talks to it over `connectOverCDP`, so
+ * most of an existing script carries over.
+ *
+ * Get the binary, or point `LIGHTPANDA_PATH=` at one you already have:
+ *
+ *   curl -Lo lightpanda https://github.com/lightpanda-io/browser/releases/latest/download/lightpanda-aarch64-macos
+ *   chmod +x lightpanda
+ *
+ * ## the connection is re-originated
+ *
+ * By default the browser does not talk to your proxy directly. It talks to a
+ * local MITM proxy (`src/mitm.ts`) that terminates TLS and makes the upstream
+ * request itself, with undici. Without that, DataDome answers Lightpanda with
+ * a `t:"bv"` — banned visitor — challenge before any JavaScript runs, purely
+ * on the connection: undici sending `User-Agent: Lightpanda/1.0` over the same
+ * proxy still gets a plain `t:"fe"`. Pass `reoriginate: false` to see that for
+ * yourself.
+ *
+ * The two flags that make it work are set here: `--ca-cert`, so the proxy's
+ * self-signed certificate is trusted, and
+ * `--insecure-disable-tls-host-verification`, because one certificate serves
+ * every host. They apply to this one browser process, which only ever talks
+ * to the local proxy.
+ *
+ * ## three things that differ from Chrome, and bite immediately
+ *
+ *   - **Never reuse the page Lightpanda starts with.** Attaching to it leaves
+ *     Playwright waiting forever on the first navigation. Always
+ *     `context.newPage()`.
+ *   - **`context.newCDPSession()` crashes the process.** Lightpanda's reply to
+ *     `Target.attachToTarget` trips an assertion inside Playwright, which is
+ *     an uncatchable throw, not a rejected promise. So no CDP-level user-agent
+ *     override, device metrics, or identity bridge — and no way to patch the
+ *     user agent from inside the browser at all. `--user-agent` rejects any
+ *     value containing "Mozilla", and `Emulation.setUserAgentOverride` is
+ *     ignored on the wire. `mitm.ts` rewrites it upstream instead.
+ *   - **`page.content()` and `frame.content()` never return.** Use
+ *     `outerHtml()` below, which reads the DOM through `evaluate`.
+ *
+ * The proxy is a process-level flag rather than a per-context option, so a
+ * session that needs its own exit IP needs its own process — which is what
+ * `start()` gives you.
+ */
+import { spawn } from 'node:child_process';
+import { setTimeout as sleep } from 'node:timers/promises';
+
+import {
+  type Browser,
+  type BrowserContext,
+  chromium,
+  type Frame,
+  type Page,
+} from 'playwright-core';
+
+import { type Capture, type Mitm, start as startMitm } from '#src/mitm.js';
+
+const BINARY = process.env['LIGHTPANDA_PATH'] || 'lightpanda';
+const PORT = Number(process.env['LIGHTPANDA_PORT'] ?? 9222);
+const READY_TIMEOUT_MS = 10_000;
+const CDP_MAX_MESSAGE_SIZE = 32 * 1024 * 1024;
+
+export type Session = {
+  browser: Browser;
+  context: BrowserContext;
+  /** The MITM proxy in front of the browser, unless `reoriginate` was false. */
+  mitm: Mitm | undefined;
+  page: Page;
+  /** Close the browser connection and stop the Lightpanda process. */
+  stop: () => Promise<void>;
+};
+
+export type StartOptions = {
+  /**
+   * URL patterns Lightpanda drops outright (`*` is a wildcard). Interception
+   * costs a full refetch per request, so blocking analytics and tag managers
+   * at the browser takes real load off the path. It does change the request
+   * profile a bot manager sees, so block only what you are willing to be seen
+   * not loading.
+   */
+  blockUrls?: string[];
+  /**
+   * The `user-agent` and `sec-ch-ua*` the MITM claims upstream. Defaults to
+   * the DataDome profile; pass the one your solver was told about.
+   */
+  identity?: Record<string, string>;
+  // eslint-disable-next-line no-unused-vars -- function-type parameter
+  log?: (message: string) => void;
+  /**
+   * Called for every response the browser receives, decoded. This is the MITM
+   * proxy's view, so it works whether or not anything is intercepting inside
+   * Playwright. Ignored when `reoriginate` is false.
+   */
+  // eslint-disable-next-line no-unused-vars -- function-type parameter
+  onResponse?: (capture: Capture) => void;
+  /** The real proxy to reach the internet through. */
+  proxy?: string;
+  /**
+   * Send the browser's traffic out through the local MITM proxy rather than
+   * straight to `proxy`. On by default; see the header for why.
+   */
+  reoriginate?: boolean;
+};
+
+/** The whole DOM, as a string. `frame.content()` never returns on Lightpanda. */
+export const outerHtml = (frame: Frame): Promise<string> =>
+  frame.evaluate(() => document.documentElement.outerHTML);
+
+/**
+ * Spawn `lightpanda serve`, wait for the CDP port, and attach.
+ * Always `await session.stop()`: the process does not exit on its own.
+ */
+export const start = async (options: StartOptions = {}): Promise<Session> => {
+  const {
+    blockUrls = [],
+    identity,
+    log = console.log,
+    onResponse,
+    proxy,
+    reoriginate = true,
+  } = options;
+
+  const mitm = reoriginate
+    ? await startMitm({
+        debug: process.env['MITM_DEBUG'] === '1',
+        ...(identity ? { identity } : {}),
+        ...(onResponse ? { onResponse } : {}),
+        ...(proxy ? { proxy } : {}),
+      })
+    : undefined;
+  if (mitm) {
+    // Never the proxy string itself: it carries credentials.
+    const upstream = proxy ? new URL(proxy).host : 'direct';
+    log(`mitm proxy on ${mitm.url} -> ${upstream}`);
+  }
+
+  const browserProxy = mitm ? mitm.url : proxy;
+  const child = spawn(
+    BINARY,
+    [
+      'serve',
+      '--host',
+      '127.0.0.1',
+      '--port',
+      String(PORT),
+      // Playwright fulfills an intercepted request by sending the whole body
+      // back over CDP, base64'd. Lightpanda's default cap is 1MB, and it does
+      // not reject the oversized message — it drops the connection, which
+      // surfaces much later as "Target page, context or browser has been
+      // closed" on every request still in flight. One 1MB analytics bundle is
+      // enough. 32MB is plenty of headroom.
+      '--cdp-max-message-size',
+      String(CDP_MAX_MESSAGE_SIZE),
+      ...(browserProxy ? ['--http-proxy', browserProxy] : []),
+      ...(mitm
+        ? [
+            '--ca-cert',
+            mitm.caCertPath,
+            '--insecure-disable-tls-host-verification',
+          ]
+        : []),
+      ...(blockUrls.length > 0 ? ['--block-urls', blockUrls.join(',')] : []),
+    ],
+    { stdio: ['ignore', 'pipe', 'pipe'] }
+  );
+  let spawnError: Error | undefined;
+  child.once('error', (error) => {
+    spawnError = error;
+  });
+
+  const endpoint = `http://127.0.0.1:${PORT}`;
+  const deadline = Date.now() + READY_TIMEOUT_MS;
+  const kill = (): void => {
+    child.kill('SIGTERM');
+  };
+  const abort = async (error: Error): Promise<never> => {
+    kill();
+    await mitm?.stop();
+    throw error;
+  };
+
+  for (;;) {
+    if (spawnError) {
+      return await abort(
+        new Error(
+          `could not start ${BINARY}: ${spawnError.message} — set LIGHTPANDA_PATH= or put it on $PATH`
+        )
+      );
+    }
+    if (child.exitCode !== null) {
+      return await abort(
+        new Error(`${BINARY} exited with code ${child.exitCode}`)
+      );
+    }
+    try {
+      const probe = await fetch(`${endpoint}/json/version`, {
+        signal: AbortSignal.timeout(1000),
+      });
+      if (probe.ok) {
+        const version = (await probe.json()) as { Browser?: string };
+        log(
+          `lightpanda ready on ${endpoint} (${version.Browser ?? 'unknown'})`
+        );
+        break;
+      }
+    } catch {
+      // Not listening yet.
+    }
+    if (Date.now() > deadline) {
+      return await abort(
+        new Error(
+          `${BINARY} did not open a CDP port on ${PORT} within ${READY_TIMEOUT_MS}ms`
+        )
+      );
+    }
+    await sleep(100);
+  }
+
+  const browser = await chromium.connectOverCDP(endpoint);
+  const context = browser.contexts()[0];
+  if (!context) {
+    await browser.close().catch(() => undefined);
+    return await abort(new Error('lightpanda opened no browser context'));
+  }
+  // A fresh page, never the one Lightpanda started with — see the header.
+  const page = await context.newPage();
+
+  return {
+    browser,
+    context,
+    mitm,
+    page,
+    stop: async (): Promise<void> => {
+      await browser.close().catch(() => undefined);
+      kill();
+      await mitm?.stop();
+      // Let the port go before anything claims it again.
+      await sleep(250);
+    },
+  };
+};

--- a/src/mitm.ts
+++ b/src/mitm.ts
@@ -1,0 +1,460 @@
+/**
+ * This is a helper library, not a script. It runs a local HTTPS proxy that
+ * **re-originates** every request through Node, and it is what makes the
+ * Lightpanda examples work at all.
+ *
+ * ## why
+ *
+ * DataDome hands Lightpanda a `t:"bv"` challenge — a banned visitor — before
+ * it has run a line of JavaScript. It is not the user agent: undici sending
+ * `User-Agent: Lightpanda/1.0` over the same proxy still gets a plain
+ * `t:"fe"`. It is the connection itself — Lightpanda's TLS stack, not its
+ * headers.
+ *
+ * You cannot dress that up from inside the browser. `--user-agent` rejects
+ * any value containing "Mozilla", `Emulation.setUserAgentOverride` is ignored
+ * on the wire, and nothing exposes the TLS layer. But every request already
+ * goes through a proxy — so put one in the middle that terminates TLS and
+ * makes the upstream request itself:
+ *
+ *   lightpanda --http-proxy http://127.0.0.1:port  ->  this  ->  your proxy
+ *
+ * Upstream, the request is undici's: the same client `grainger-undici.ts`
+ * uses, with the same TLS fingerprint DataDome already accepts. Lightpanda
+ * keeps the DOM, the cookie jar and the JavaScript; it just stops being the
+ * thing that opens the socket.
+ *
+ * ## what it does to a request
+ *
+ *   - rewrites `user-agent` and the `sec-ch-*` hints to the Chrome identity in
+ *     `profile.ts`, so the headers agree with the profile the solver is given
+ *   - decompresses the response and forwards it decoded, dropping
+ *     `content-encoding` and `content-length` to match
+ *   - never follows redirects — the browser owns navigation
+ *   - hands every response to `onResponse`, which is how the Akamai example
+ *     captures the sensor script without Playwright's `route.fetch`
+ *
+ * ## the certificate
+ *
+ * One self-signed certificate, generated with `openssl` into `target/` on
+ * first use and reused after that. It is served for every host, which works
+ * because Lightpanda is started with `--ca-cert` pointing at it (so it is a
+ * trusted root) and `--insecure-disable-tls-host-verification` (so the name
+ * mismatch is not fatal). Both flags apply to the one browser process this
+ * library starts, which only ever talks to this proxy.
+ */
+import { execFile } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync } from 'node:fs';
+import { createServer, type IncomingMessage, type Server } from 'node:http';
+import type { Socket } from 'node:net';
+import { join } from 'node:path';
+import { TLSSocket } from 'node:tls';
+import { promisify } from 'node:util';
+
+import { ProxyAgent, fetch as undiciFetch } from 'undici';
+
+import { PROFILE } from '#src/datadome/profile.js';
+
+const execFileAsync = promisify(execFile);
+const CERT_DIR = join(process.cwd(), 'target', 'lightpanda-mitm');
+const CERT_PATH = join(CERT_DIR, 'cert.pem');
+const KEY_PATH = join(CERT_DIR, 'key.pem');
+
+/** Hop-by-hop headers, which belong to one connection and must not be relayed. */
+const HOP_BY_HOP = new Set([
+  'connection',
+  'keep-alive',
+  'proxy-authenticate',
+  'proxy-authorization',
+  'te',
+  'trailer',
+  'transfer-encoding',
+  'upgrade',
+]);
+
+/**
+ * The identity we claim upstream, whatever the browser had to say about it.
+ * Defaults to the DataDome profile; the Akamai example overrides it, because
+ * that solver models a different Chrome and the two have to agree — the
+ * telemetry claims one browser and the headers must not claim another.
+ */
+const DEFAULT_IDENTITY: Record<string, string> = {
+  'sec-ch-ua': PROFILE.brands
+    .map(({ brand, version }) => `"${brand}";v="${version}"`)
+    .join(', '),
+  'sec-ch-ua-mobile': '?0',
+  'sec-ch-ua-platform': '"macOS"',
+  'user-agent': PROFILE.userAgent,
+};
+
+/**
+ * Chrome's header order, which is part of the fingerprint. Anything the
+ * browser sent that is not in this list follows, in its own order.
+ */
+const CHROME_ORDER = [
+  'sec-ch-ua',
+  'sec-ch-ua-mobile',
+  'sec-ch-ua-platform',
+  'upgrade-insecure-requests',
+  'user-agent',
+  'accept',
+  'origin',
+  'referer',
+  'sec-fetch-site',
+  'sec-fetch-mode',
+  'sec-fetch-user',
+  'sec-fetch-dest',
+  'accept-language',
+  'cookie',
+  'priority',
+];
+
+/**
+ * Lightpanda sends six headers and no more: host, accept, accept-encoding,
+ * accept-language, user-agent, sec-ch-ua. Chrome sends the `sec-fetch-*` set
+ * on every request and `upgrade-insecure-requests` on navigations, and their
+ * absence is conspicuous — grainger.com answers a request without them with
+ * its own error page rather than the real one. Fill in what the browser did
+ * not send, inferring the request's kind from `accept`, which is the one
+ * signal Lightpanda does vary.
+ */
+const fetchMetadata = (
+  headers: Record<string, string>,
+  targetUrl: string,
+  method: string
+): Record<string, string> => {
+  const accept = headers['accept'] ?? '';
+  const isDocument = accept.startsWith('text/html');
+  const referer = headers['referer'];
+  // A body means `fetch()` or XHR, not a tag load. Chrome sends `Origin` on
+  // every such request, even same-origin, and Lightpanda sends none —
+  // `Origin` is a forbidden header name, so the page cannot add it either.
+  // DataDome checks for it: without it the solve is accepted and the cookie
+  // it hands back is void on first use.
+  const isApiCall = method !== 'GET' && method !== 'HEAD';
+  let site = 'none';
+  if (referer) {
+    try {
+      site =
+        new URL(referer).origin === new URL(targetUrl).origin
+          ? 'same-origin'
+          : 'cross-site';
+    } catch {
+      site = 'cross-site';
+    }
+  }
+  return isDocument
+    ? {
+        // Lightpanda's document `accept` is the short form; Chrome 1xx sends
+        // the image formats too. DataDome reads it: with the short form it
+        // serves a captcha, with Chrome's it serves an interstitial.
+        accept:
+          'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8',
+        priority: 'u=0, i',
+        'sec-fetch-dest': 'document',
+        'sec-fetch-mode': 'navigate',
+        'sec-fetch-site': site,
+        'sec-fetch-user': '?1',
+        'upgrade-insecure-requests': '1',
+      }
+    : {
+        ...(isApiCall && !headers['origin'] && referer
+          ? { origin: new URL(referer).origin }
+          : {}),
+        priority: 'u=1, i',
+        'sec-fetch-dest': accept.includes('image/') ? 'image' : 'empty',
+        'sec-fetch-mode': isApiCall || headers['origin'] ? 'cors' : 'no-cors',
+        'sec-fetch-site': site === 'none' ? 'same-origin' : site,
+      };
+};
+
+export type Capture = {
+  body: string;
+  headers: Record<string, string>;
+  /** Every `set-cookie` on the response, unjoined. */
+  setCookie: string[];
+  status: number;
+  url: string;
+};
+
+export type Forwarded = {
+  body: string;
+  headers: Record<string, string>;
+  setCookie: string[];
+  status: number;
+};
+
+export type Mitm = {
+  caCertPath: string;
+  /**
+   * Make a request through this proxy without a browser involved — same
+   * dispatcher, same identity, same exit IP. `src/akamai/comcast-lightpanda.ts`
+   * hands this to the solver in place of Playwright's `route.fetch`, which
+   * stalls against Lightpanda.
+   */
+  fetch: (
+    // eslint-disable-next-line no-unused-vars -- function-type parameters
+    request: {
+      body?: string;
+      headers?: Record<string, string>;
+      method?: string;
+      url: string;
+    }
+  ) => Promise<Forwarded>;
+  port: number;
+  stop: () => Promise<void>;
+  url: string;
+};
+
+export type MitmOptions = {
+  /**
+   * Log one line per request, with the headers as sent upstream. This is the
+   * only place the real request is visible — Playwright reports what the
+   * browser asked for, not what went out.
+   */
+  debug?: boolean;
+  /**
+   * The `user-agent` and `sec-ch-ua*` headers to claim upstream. Must match
+   * whatever profile the solver you are using was told about.
+   */
+  identity?: Record<string, string>;
+  /** Called for every response, after decoding. Errors here are swallowed. */
+  // eslint-disable-next-line no-unused-vars -- function-type parameter
+  onResponse?: (capture: Capture) => void;
+  /** The real proxy to go out through. Direct when omitted. */
+  proxy?: string;
+};
+
+/**
+ * One self-signed certificate, generated on first use. `openssl` ships with
+ * macOS and every CI image this repo runs on; there is no Node API for this.
+ */
+const ensureCertificate = async (): Promise<{ cert: Buffer; key: Buffer }> => {
+  if (!existsSync(CERT_PATH) || !existsSync(KEY_PATH)) {
+    mkdirSync(CERT_DIR, { recursive: true });
+    await execFileAsync('openssl', [
+      'req',
+      '-x509',
+      '-newkey',
+      'rsa:2048',
+      '-nodes',
+      '-days',
+      '365',
+      '-subj',
+      '/CN=lightpanda-mitm',
+      '-addext',
+      'subjectAltName=DNS:lightpanda-mitm,DNS:localhost',
+      '-keyout',
+      KEY_PATH,
+      '-out',
+      CERT_PATH,
+    ]);
+  }
+  return {
+    cert: readFileSync(CERT_PATH),
+
+    key: readFileSync(KEY_PATH),
+  };
+};
+
+/** Read a request body into one buffer. */
+const readBody = async (req: IncomingMessage): Promise<Buffer | undefined> => {
+  if (req.method === 'GET' || req.method === 'HEAD') return undefined;
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) chunks.push(chunk as Buffer);
+  return chunks.length > 0 ? Buffer.concat(chunks) : undefined;
+};
+
+/** Start the proxy. Resolves once it is listening. */
+export const start = async (options: MitmOptions = {}): Promise<Mitm> => {
+  const {
+    debug = false,
+    identity = DEFAULT_IDENTITY,
+    onResponse,
+    proxy,
+  } = options;
+  const { cert, key } = await ensureCertificate();
+  const dispatcher = proxy ? new ProxyAgent(proxy) : undefined;
+  const sockets = new Set<Socket>();
+
+  /**
+   * The one place a request leaves this process: header rewrite, upstream
+   * call, decode. Used by the proxy server and by `mitm.fetch`, so both put
+   * exactly the same thing on the wire.
+   */
+  const forward = async (request: {
+    body?: Buffer | string;
+    headers: Record<string, string>;
+    method: string;
+    url: string;
+  }): Promise<Forwarded> => {
+    const incoming: Record<string, string> = {};
+    for (const [name, value] of Object.entries(request.headers)) {
+      if (HOP_BY_HOP.has(name) || value === undefined) continue;
+      // `host` becomes the authority from the URL; `accept-encoding` is
+      // undici's to negotiate, since we forward the response decoded.
+      if (name === 'host' || name === 'accept-encoding') continue;
+      incoming[name] = value;
+    }
+    const merged: Record<string, string> = {
+      ...incoming,
+      ...fetchMetadata(incoming, request.url, request.method),
+      ...identity,
+    };
+    // Reassemble in Chrome's order: header order is fingerprinted too.
+    const headers: Record<string, string> = {};
+    for (const name of CHROME_ORDER) {
+      if (merged[name] !== undefined) headers[name] = merged[name];
+    }
+    for (const [name, value] of Object.entries(merged)) {
+      if (headers[name] === undefined) headers[name] = value;
+    }
+
+    if (debug) {
+      console.log(
+        `[mitm] ${request.method} ${request.url}\n` +
+          Object.entries(headers)
+            .map(([name, value]) => `        ${name}: ${value}`)
+            .join('\n')
+      );
+    }
+
+    // undici's `fetch`, deliberately: it is the client the browser-free
+    // examples use, down to the `accept-encoding` it adds and the
+    // decompression it does. `request` sends no `accept-encoding` at all, and
+    // DataDome answers a request without one with a captcha where the same
+    // request with one gets an interstitial.
+    const upstream = await undiciFetch(request.url, {
+      ...(dispatcher ? { dispatcher } : {}),
+      ...(request.body === undefined ? {} : { body: request.body }),
+      headers,
+      method: request.method,
+      redirect: 'manual',
+    });
+    const text = await upstream.text();
+
+    const upstreamHeaders: Record<string, string> = {};
+    for (const [name, value] of upstream.headers) upstreamHeaders[name] = value;
+
+    const forwarded: Forwarded = {
+      body: text,
+      headers: upstreamHeaders,
+      // `set-cookie` is the one header that legitimately repeats, and joining
+      // it with commas would corrupt Expires dates.
+      setCookie: upstream.headers.getSetCookie(),
+      status: upstream.status,
+    };
+
+    if (onResponse) {
+      try {
+        onResponse({
+          body: text,
+          headers: upstreamHeaders,
+          setCookie: forwarded.setCookie,
+          status: upstream.status,
+          url: request.url,
+        });
+      } catch {
+        // A capture hook must never take down the request it observed.
+      }
+    }
+    return forwarded;
+  };
+
+  // The HTTP server that parses requests off each terminated TLS connection.
+  // Requests arriving here have already been CONNECTed, so `req.url` is a path
+  // and the authority comes from the Host header.
+  const inner: Server = createServer((req, res) => {
+    void (async (): Promise<void> => {
+      const host = req.headers.host ?? '';
+      const target = `https://${host}${req.url ?? '/'}`;
+      try {
+        const headers: Record<string, string> = {};
+        for (const [name, value] of Object.entries(req.headers)) {
+          if (value === undefined) continue;
+          headers[name] = Array.isArray(value) ? value.join(', ') : value;
+        }
+        const body = await readBody(req);
+        const upstream = await forward({
+          ...(body ? { body } : {}),
+          headers,
+          method: req.method ?? 'GET',
+          url: target,
+        });
+
+        const outHeaders: Record<string, string | string[]> = {};
+        for (const [name, value] of Object.entries(upstream.headers)) {
+          // The body is decoded and reframed, so the original framing headers
+          // would be lies. Everything else passes.
+          if (
+            HOP_BY_HOP.has(name) ||
+            name === 'content-encoding' ||
+            name === 'content-length' ||
+            name === 'set-cookie'
+          ) {
+            continue;
+          }
+          outHeaders[name] = value;
+        }
+        if (upstream.setCookie.length > 0) {
+          outHeaders['set-cookie'] = upstream.setCookie;
+        }
+
+        res.writeHead(upstream.status, outHeaders);
+        res.end(upstream.body);
+      } catch (error) {
+        // 502 is the honest answer, and it surfaces in the browser as a failed
+        // request rather than a hang.
+        res.writeHead(502, { 'content-type': 'text/plain' });
+        res.end(`mitm: ${(error as Error).message}`);
+      }
+    })();
+  });
+
+  // The proxy endpoint Lightpanda points at. Only CONNECT matters — every
+  // target in these examples is https.
+  const outer: Server = createServer((_req, res) => {
+    res.writeHead(405, { 'content-type': 'text/plain' });
+    res.end('mitm: this proxy only handles CONNECT');
+  });
+
+  outer.on('connect', (_req, socket: Socket) => {
+    sockets.add(socket);
+    socket.on('close', () => sockets.delete(socket));
+    socket.on('error', () => socket.destroy());
+    socket.write('HTTP/1.1 200 Connection Established\r\n\r\n');
+    // Terminate TLS ourselves, then hand the decrypted stream to `inner` as if
+    // it were an ordinary connection.
+    const tlsSocket = new TLSSocket(socket, { cert, isServer: true, key });
+    tlsSocket.on('error', () => tlsSocket.destroy());
+    inner.emit('connection', tlsSocket);
+  });
+
+  await new Promise<void>((resolve) => outer.listen(0, '127.0.0.1', resolve));
+  const address = outer.address();
+  if (address === null || typeof address === 'string') {
+    throw new Error('mitm: could not determine the listening port');
+  }
+  const { port } = address;
+
+  return {
+    caCertPath: CERT_PATH,
+    fetch: (request) =>
+      forward({
+        ...(request.body === undefined ? {} : { body: request.body }),
+        headers: request.headers ?? {},
+        method: request.method ?? 'GET',
+        url: request.url,
+      }),
+    port,
+    stop: async (): Promise<void> => {
+      for (const socket of sockets) socket.destroy();
+      await Promise.all([
+        new Promise<void>((resolve) => outer.close(() => resolve())),
+        new Promise<void>((resolve) => inner.close(() => resolve())),
+      ]);
+      await dispatcher?.close();
+    },
+    url: `http://127.0.0.1:${port}`,
+  };
+};


### PR DESCRIPTION
Adds Lightpanda examples for both products — `npm run comcast:lightpanda` and
`npm run grainger:lightpanda` — plus the two helpers they need,
`src/lightpanda.ts` (launcher) and `src/mitm.ts` (a local re-originating proxy).

[Lightpanda](https://lightpanda.io) is a headless browser with no renderer: a
~70MB binary that starts in milliseconds and holds a page in a few MB. It
speaks CDP, so Playwright drives it over `connectOverCDP`.

## Akamai works

`_abck` reaches `~0~` on round 5 — the round Chrome takes:

```
[https://login.xfinity.com] Cookie update: round=5 rval=0 accepted=true _abck=~0~
[https://login.xfinity.com] Cookie accepted (round 5)
RESULT: SUCCESS - Akamai solved, reached /login
```

Four things had to be true first. Each failed silently, and none looked like
what it was:

1. **The connection is re-originated.** Lightpanda's TLS gets a ban on sight,
   and its user agent cannot be changed from inside the browser — `--user-agent`
   rejects any value containing "Mozilla", `Emulation.setUserAgentOverride` is
   ignored on the wire, and `context.newCDPSession()` (how `comcast.ts`
   overrides it) crashes Playwright. So `mitm.ts` terminates TLS in front of the
   browser and re-makes each request with undici, owning the identity. Running
   **real Chrome through the same proxy** is still accepted at round 5, which is
   how we know undici's fingerprint is not the problem.
2. **The identity has to be the profile the Akamai solver was told about**
   (`chrome-146-macos`), not the proxy's DataDome default. Telemetry claiming
   146 under headers claiming 149 sits at `~-1~` for as many rounds as you give
   it.
3. **`fetchResponse` replaces `route.fetch`,** which never returns against
   Lightpanda: it runs in Playwright's request context, which syncs cookies with
   the browser, and once that stops answering every later route.fetch waits out
   its timeout — sensor script included, so no session ever opens.
4. **Cookies are applied to the jar by hand on that path.** `route.fulfill`
   carries one `set-cookie` header and Akamai's document response sets four.
   Losing `_abck` opens the session without the cookie the whole protocol
   advances; Akamai then returns the *same* `_abck` to every submission and the
   rounds count up forever. Applying them has to happen *after* fulfilling —
   awaiting `addCookies` while a route is paused deadlocks Lightpanda.

Two more that look like bugs and are not, both handled in `lightpanda.ts`:
Lightpanda's 1MB default CDP message cap (Playwright fulfills by sending the
whole body back base64'd, so one 1MB analytics bundle silently drops the
connection), and the solver's 30s/15s navigation timeouts, which a page this
heavy overruns.

## DataDome works, intermittently

The solver's DataDome path has since been fixed, and this was re-run against
it. `grainger-undici.ts` now solves and verifies on the first attempt, 4 runs
out of 4 — so the blocker this PR originally described is gone.

The Lightpanda example gets through too. A verified attempt returns the real
page and DataDome rotates the cookie:

```
clearance cookie: datadome=QTlff_rUpD_JXTy6VJjnQ0wA9hB7akP68m1D2t678Gh_…
verifying against the target
  <- HTTP 200 (489743 bytes) "Grainger Industrial Supply - MRO Products…"
```

But only **5 attempts in 20**. The other 15 earn a clearance cookie that is
refused on first use and come back as a fresh `rt=c t=fe`. With the three
attempts the runner makes, a run succeeded 5 times out of 8.

undici on the same proxy, in the same minute, verifies first time every time —
so what is borderline is the solve computed from a Lightpanda page, not the
solver, the proxy, or the IP. The mechanical suspects were checked and are
clean: the challenge document is byte-identical across attempts (468521), the
verify request carries the right cookie and nothing stale, and cookie shape
does not correlate with the outcome. Root-causing which environment signals
Lightpanda cannot produce convincingly is left to a follow-up; the example
retries rather than expecting a hit, and a failed attempt costs ~7s.

Two findings from that work are baked into the proxy and matter generally: a
request with **no `accept-encoding`** gets a captcha where the same request
with one gets an interstitial (so the proxy uses `undici.fetch`, not
`request`), and without synthesized `sec-fetch-*` headers grainger.com serves
its own error page instead of the real one.

## Changes to shared code

`src/akamai/solver.ts` gains three optional `SolveOptions` — `fetchResponse`,
`navigationTimeout`, `loadStateTimeout` — the last two replacing hard-coded
30s/15s values and defaulting to them. The cookie handling on the
`fetchResponse` path is new; the `route.fetch` path is untouched, since
Playwright applies cookies itself there. Each session now logs its cookies by
name, which is what made the `_abck` bug visible.

## Testing

- `npm run comcast:lightpanda` — SUCCESS, accepted round 5, three times
- `npm run comcast` (Chrome, unchanged path) — SUCCESS, accepted round 5
- Chrome forced through the MITM proxy — SUCCESS, accepted round 5
- `npm run grainger` (undici baseline) — SUCCESS on the first attempt, 4/4 runs
- `npm run grainger:lightpanda` — SUCCESS in 5 of 8 runs (5 of 20 attempts)
- `make lint`, `npm run build`, `npm run depcheck` clean

Requires the `lightpanda` binary on `$PATH` or `LIGHTPANDA_PATH=`; the MITM's
self-signed certificate is generated with `openssl` into `target/` on first use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
