### PR TITLE
ci: reduce Actions cache storage from docker builds

### DIFF
--- a/.github/workflows/cleanup-pr-caches.yml
+++ b/.github/workflows/cleanup-pr-caches.yml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: cleanup pr caches
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-slim
+    permissions:
+      actions: write
+    steps:
+      - name: Delete caches scoped to this PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          BRANCH: refs/pull/${{ github.event.pull_request.number }}/merge
+        run: |
+          gh extension install actions/gh-actions-cache
+          cacheKeysForPR=$(gh actions-cache list -R "$REPO" -B "$BRANCH" -L 100 | cut -f 1)
+          set +e
+          for cacheKey in $cacheKeysForPR; do
+            gh actions-cache delete "$cacheKey" -R "$REPO" -B "$BRANCH" --confirm
+          done

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -99,7 +99,7 @@ jobs:
           push: false
           tags: examples
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-to: type=gha,mode=min
 
   dependabot-approve-and-automerge:
     runs-on: ubuntu-slim


### PR DESCRIPTION
## Summary
- Switch buildkit `cache-to` from `mode=max` to `mode=min` in the docker-build job — keeps final-layer cache only instead of every intermediate layer blob.
- Adds a workflow that deletes caches scoped to a PR's ref when the PR closes/merges.

## Why
We hit 90% of the 2GB Actions storage budget. This repo alone held 959MB across 26 caches from a single PR, mostly `buildkit-blob-*` entries up to 261MB each from `mode=max`. Manually cleared the existing stale caches from PR #40 already.

## Test plan
- [ ] Open a PR touching the Dockerfile and confirm docker-build still restores/uses cache correctly with `mode=min`
- [ ] Merge that PR and confirm the cleanup job removes its caches via `gh api repos/xhrdev/examples/actions/caches`