### PR TITLE
ci: call shared cleanup-pr-caches workflow instead of duplicating it

### DIFF
--- a/.github/workflows/cleanup-pr-caches.yml
+++ b/.github/workflows/cleanup-pr-caches.yml
@@ -1,4 +1,3 @@
-# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 name: cleanup pr caches
 
 on:
@@ -7,20 +6,7 @@ on:
       - closed
 
 jobs:
-  cleanup:
-    runs-on: ubuntu-slim
+  cleanup-pr-caches:
+    uses: xhrdev/actions/.github/workflows/cleanup-pr-caches.yml@master
     permissions:
       actions: write
-    steps:
-      - name: Delete caches scoped to this PR
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
-          BRANCH: refs/pull/${{ github.event.pull_request.number }}/merge
-        run: |
-          gh extension install actions/gh-actions-cache
-          cacheKeysForPR=$(gh actions-cache list -R "$REPO" -B "$BRANCH" -L 100 | cut -f 1)
-          set +e
-          for cacheKey in $cacheKeysForPR; do
-            gh actions-cache delete "$cacheKey" -R "$REPO" -B "$BRANCH" --confirm
-          done


### PR DESCRIPTION
The previous PR (#41) merged with the standalone version of this workflow before the follow-up commit switching it to call the shared xhrdev/actions reusable workflow could land. This aligns examples with the other 15 repos and picks up a since-fixed bug (cache keys containing spaces broke the original inline script's word-splitting).