### PR TITLE
fix: inline the cleanup-pr-caches script (examples is public, xhrdev/actions is private)

### DIFF
--- a/.github/workflows/cleanup-pr-caches.yml
+++ b/.github/workflows/cleanup-pr-caches.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 name: cleanup pr caches
 
 on:
@@ -7,6 +8,18 @@ on:
 
 jobs:
   cleanup-pr-caches:
-    uses: xhrdev/actions/.github/workflows/cleanup-pr-caches.yml@master
+    runs-on: ubuntu-slim
     permissions:
       actions: write
+    steps:
+      - name: Delete caches scoped to this PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          BRANCH: refs/pull/${{ github.event.pull_request.number }}/merge
+        run: |
+          gh extension install actions/gh-actions-cache
+          set +e
+          gh actions-cache list -R "$REPO" -B "$BRANCH" -L 100 | cut -f 1 | while IFS= read -r cacheKey; do
+            gh actions-cache delete "$cacheKey" -R "$REPO" -B "$BRANCH" --confirm
+          done


### PR DESCRIPTION
#42 switched this to call xhrdev/actions' shared reusable workflow, but that repo is private and examples is public — GitHub blocks a public repo from consuming a private repo's reusable workflow, so every run failed immediately with '0 jobs / workflow file issue' (see run 32308574129). This inlines the script directly instead, carrying forward the space-in-cache-key fix from xhrdev/actions#31.