### PR TITLE
feat: make proxy= optional

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,8 +15,18 @@
 # clearance cookies the solver returns travel in cleartext.
 host=<solver-host-or-ip>
 
-# Upstream proxy the examples egress through. Bot vendors bind their clearance
-# cookies to the egress IP, so this must be the same network you scrape from.
+## --- optional ---------------------------------------------------------------
+
+# Upstream proxy the examples egress through. Optional: leave it unset and
+# everything goes out from this machine instead, which is a fine way to try the
+# flow and a real deployment for a box that already egresses where you want it
+# to. Bot vendors bind their clearance cookies to the egress IP, so whichever
+# you pick, solve and browse from the same place.
+#
+# One exception today: DataDome *captcha* solves fail without a proxy — the
+# sandbox cannot fetch the captcha's stylesheet asset and answers
+# `HTTP 500 DD solve error`. Interstitials and the whole Akamai flow are fine
+# without one.
 #
 # The examples pin a sticky session automatically for oxylabs (`-sessid-`) and
 # rayobyte (`-hardsession-`); with any other provider, make sure the pool does
@@ -24,9 +34,7 @@ host=<solver-host-or-ip>
 #
 # Datacenter IPs are faster, but some sites do not bother challenging them at
 # all — use a residential pool if you want to exercise the solve path.
-proxy=http://<user>:<pass>@<proxy-host>:<port>
-
-## --- optional ---------------------------------------------------------------
+# proxy=http://<user>:<pass>@<proxy-host>:<port>
 
 # Only if your deployment gates the solver behind an API key (sent as
 # `x-api-key`). Leave unset for an ungated container on a private network.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ worked.
 
 ```bash
 npm ci
-cp .env.example .env   # then fill in host= and proxy=
+cp .env.example .env   # then fill in host= (proxy= is optional)
 
 # only if you want the Python examples
 python3 -m venv venv && ./venv/bin/pip install -r requirements.txt
@@ -288,7 +288,27 @@ the first three.
 
 ## proxies
 
-Clearance cookies are bound to the IP that earned them. Two things follow:
+`proxy=` is optional. Leave it unset and every example goes out from the
+machine it runs on — the challenge, the solve and the submission all from one
+address, which is the only thing the bot vendors actually require. That is the
+simplest way to try the flow, and it is a real deployment for a box that
+already egresses where you want it to. The scripts say `DIRECT` instead of
+`PROXY` in their log lines so you can tell which mode you are in.
+
+**DataDome captcha solves are the exception, for now.** With no `proxy` in the
+solve body the sandbox cannot fetch the captcha's own stylesheet
+(`static.captcha-delivery.com/captcha/assets/tpl/.../index.css`) and the solve
+ends as `HTTP 500 DD solve error`, which names nothing — so the examples add a
+hint when that lands on a proxy-less run. It is a solver-side fix, not
+something to work around here, and it is not the profile: the same challenge
+solves on the first try when a proxy is declared. DataDome interstitials
+(`rt:"i"`) and the whole Akamai flow already work with no proxy at all —
+Akamai relays its sensors through your own browser, so there is nothing to
+route.
+
+Set it when you need someone else's exit IP: a residential pool to exercise
+the solve path, or geography the target expects. Then clearance cookies are
+bound to the IP that earned them, and two things follow:
 
 1. **Pin a session.** If your proxy pool rotates mid-flow, the cookie you get
    back is already void. `src/proxy.ts` handles this for every provider we
@@ -348,6 +368,8 @@ Drop `--headless` to watch a browser-based script work.
 | `no challenge to solve` | the site let your IP through. Try a residential proxy. |
 | a fresh 403 right after a successful solve | the cookie was earned on a different IP — check session pinning, and that you sent the submission yourself |
 | `RESULT: FAIL - proxy session failed` | dead exit node. The examples retry three times; raise it with `--attempts=5` |
+| `RESULT: FAIL - network error` | same, with no `proxy=` set: the transport failed from this machine |
+| `HTTP 500 DD solve error` on a `DIRECT` run | DataDome captcha solves need a proxy; set `proxy=` in `.env` |
 | solver returns 400 | the profile and the headers you send disagree. Change both together, never one alone |
 | solver returns 500 with `queue_full` | the container is saturated; check `GET /akamai/queue-metrics` |
 | `RESULT: FAIL - rate limit hit` | the solver answered 429. See rate limits below |

--- a/dev-resources/curl
+++ b/dev-resources/curl
@@ -86,7 +86,7 @@ req() {
   local out status
   out="$1"; shift
   if ! status="$(curl -sS "$@" -o "$out" -w '%{http_code}' 2>"${work}/curl.err")"; then
-    fail "proxy session failed ($(tr -d '\n' <"${work}/curl.err" | head -c 120))"
+    fail "${transport_failure} ($(tr -d '\n' <"${work}/curl.err" | head -c 120))"
   fi
   printf '%s' "$status"
 }
@@ -95,16 +95,30 @@ command -v jq >/dev/null || fail 'jq is required (brew install jq)'
 
 # --- pin the proxy session ------------------------------------------------
 #
-# Clearance cookies are bound to the IP that earned them, so the pool must
-# not rotate between step 1 and step 4. Providers spell this differently;
-# see src/proxy.ts for the full set.
+# proxy= is optional: with none set, `via` is empty and every request below
+# goes out from this machine — which is all DataDome asks, as long as the
+# submission in step 4 comes from the same address as step 1.
+#
+# With one set, clearance cookies are bound to the IP that earned them, so the
+# pool must not rotate between step 1 and step 4. Providers spell this
+# differently; see src/proxy.ts for the full set.
 session="$RANDOM$RANDOM"
 case "$proxy" in
+  '')            pinned='' ;;
   *oxylabs.io*)  pinned="${proxy/:\/\//://}"
                  pinned="$(printf '%s' "$proxy" | sed -E "s|://([^:]+):|://\1-sessid-${session}:|")" ;;
   *rayobyte.com*) pinned="$(printf '%s' "$proxy" | sed -E "s|://([^:]+):([^@]+)@|://\1:\2-hardsession-${session}@|")" ;;
   *)             pinned="$proxy" ;;
 esac
+
+if [ -n "$pinned" ]; then
+  via=(-x "$pinned")
+  transport_failure='proxy session failed'
+else
+  via=()
+  transport_failure='network error'
+  log "no proxy= set — going out from this machine's address"
+fi
 
 ua='Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.0.0 Safari/537.36'
 nav=(
@@ -123,7 +137,7 @@ nav=(
 
 # --- 1. trip the challenge ------------------------------------------------
 log "GET ${target}"
-status="$(req "${work}/blocked.html" -m 60 -x "$pinned" "${nav[@]}" "$target")"
+status="$(req "${work}/blocked.html" -m 60 "${via[@]}" "${nav[@]}" "$target")"
 log "  <- HTTP ${status} ($(wc -c <"${work}/blocked.html" | tr -d ' ') bytes)"
 
 # The block page carries `var dd={'rt':'c',...}` — single-quoted, so swap the
@@ -159,7 +173,7 @@ doc_url="$(jq -rn --argjson dd "$dd" --arg geo "$geo" --arg ref "$target" '
   | $geo + $path + "?" + join("&")')"
 
 log 'GET challenge document'
-status="$(req "${work}/document.html" -m 60 -x "$pinned" "${nav[@]}" \
+status="$(req "${work}/document.html" -m 60 "${via[@]}" "${nav[@]}" \
   -H "referer: ${target}" \
   -H 'sec-fetch-dest: iframe' \
   -H 'sec-fetch-site: cross-site' \
@@ -218,10 +232,10 @@ jq -n \
         tlsClientHello: "",
         userAgent: $ua
       },
-      proxy: $proxy,
       timeout: 120000,
       url: $url
-    }' >"${work}/solve.json"
+    }
+  | (if $proxy == "" then . else . + { proxy: $proxy } end)' >"${work}/solve.json"
 
 log 'POST /dd/solve'
 status="$(req "${work}/prepared.json" -m 130 \
@@ -257,11 +271,11 @@ submit=(
 if [ -n "$body" ]; then
   log 'POST submission'
   printf '%s' "$body" >"${work}/submission.txt"
-  status="$(req "${work}/submitted.json" -m 60 -x "$pinned" "${submit[@]}" \
+  status="$(req "${work}/submitted.json" -m 60 "${via[@]}" "${submit[@]}" \
     --data-binary "@${work}/submission.txt" "$submit_url")"
 else
   log 'GET submission'
-  status="$(req "${work}/submitted.json" -m 60 -x "$pinned" "${submit[@]}" "$submit_url")"
+  status="$(req "${work}/submitted.json" -m 60 "${via[@]}" "${submit[@]}" "$submit_url")"
 fi
 log "  <- HTTP ${status}"
 
@@ -273,7 +287,7 @@ log "clearance cookie: datadome=${cookie}"
 
 # --- prove it -------------------------------------------------------------
 log 'verifying against the target'
-status="$(req "${work}/verified.html" -m 60 -x "$pinned" "${nav[@]}" \
+status="$(req "${work}/verified.html" -m 60 "${via[@]}" "${nav[@]}" \
   -H "cookie: datadome=${cookie}" "$target")"
 title="$(sed -n 's/.*<title>\([^<]*\).*/\1/p' "${work}/verified.html" | head -1)"
 log "  <- HTTP ${status} ($(wc -c <"${work}/verified.html" | tr -d ' ') bytes) \"${title}\""

--- a/dev-resources/repl.cjs
+++ b/dev-resources/repl.cjs
@@ -42,15 +42,17 @@ async function main() {
   const solverHost = process.env.host;
   const solverUrl = solverHost ? `http://${solverHost}:3000` : undefined;
 
-  if (!process.env.proxy) throw new Error('set proxy= in .env');
-  const { url: proxy } = pinSession(process.env.proxy);
+  // proxy= is optional here too: unset, everything goes out from this box.
+  const proxy = process.env.proxy ? pinSession(process.env.proxy).url : undefined;
 
-  // Same client as grainger-axios.ts: the jar lives in the proxy agent.
+  // Same client as grainger-axios.ts: the jar lives in the agent.
   const HttpsProxyCookieAgent = cookieAgent.createCookieAgent(hpa.HttpsProxyAgent);
   const jar = new tough.CookieJar();
   const client = cookieSupport.wrapper(
     axios.create({
-      httpsAgent: new HttpsProxyCookieAgent(proxy, { cookies: { jar } }),
+      httpsAgent: proxy
+        ? new HttpsProxyCookieAgent(proxy, { cookies: { jar } })
+        : new cookieAgent.HttpsCookieAgent({ cookies: { jar } }),
       proxy: false,
       validateStatus: () => true,
     })
@@ -107,7 +109,7 @@ async function main() {
   };
 
   console.log(`xhr.dev playground — target ${target}`);
-  console.log(`  proxy  ${proxy.replace(/:[^:@]*@/, ':***@')}`);
+  console.log(`  proxy  ${proxy ? proxy.replace(/:[^:@]*@/, ':***@') : 'none (direct)'}`);
   console.log(`  solver ${solverUrl ?? 'NOT SET (set host= in .env)'}`);
   console.log('  try:   const dd = parseBlockPage(await get())\n');
 

--- a/py-src/datadome/grainger_httpx.py
+++ b/py-src/datadome/grainger_httpx.py
@@ -41,6 +41,7 @@ from datadome.http_utils import (  # noqa: E402
 
 
 def attempt(proxy, api_key, solver_url, target_url):
+  # `proxy=None` is httpx's own default: a client that goes direct.
   with httpx.Client(
     follow_redirects=True, proxy=proxy, timeout=TIMEOUT_S
   ) as client:

--- a/py-src/datadome/grainger_requests.py
+++ b/py-src/datadome/grainger_requests.py
@@ -58,7 +58,8 @@ from datadome.http_utils import (  # noqa: E402
 
 def attempt(proxy, api_key, solver_url, target_url):
   session = requests.Session()
-  session.proxies = {'http': proxy, 'https': proxy}
+  if proxy:
+    session.proxies = {'http': proxy, 'https': proxy}
 
   # 1. Trip the challenge.
   log(f'GET {target_url}')

--- a/py-src/datadome/grainger_urllib.py
+++ b/py-src/datadome/grainger_urllib.py
@@ -103,14 +103,19 @@ def _send(opener, url, headers, data=None, method=None):
 
 
 def attempt(proxy, api_key, solver_url, target_url):
-  # Credentials ride along in the proxy URL; urllib turns them into the
-  # Proxy-Authorization header on the CONNECT.
-  proxied = urllib.request.build_opener(
-    urllib.request.ProxyHandler({'http': proxy, 'https': proxy})
-  )
   # An empty ProxyHandler means "no proxy", which is how the solver call
   # stays on your own network.
   direct = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+  # Credentials ride along in the proxy URL; urllib turns them into the
+  # Proxy-Authorization header on the CONNECT. With no proxy configured
+  # the target traffic uses the same direct opener as the solver call.
+  proxied = (
+    urllib.request.build_opener(
+      urllib.request.ProxyHandler({'http': proxy, 'https': proxy})
+    )
+    if proxy
+    else direct
+  )
 
   # 1. Trip the challenge.
   log(f'GET {target_url}')

--- a/py-src/datadome/http_utils.py
+++ b/py-src/datadome/http_utils.py
@@ -172,7 +172,7 @@ def solve_request_body(dd, document_html, document_url, proxy, target_url):
     if dd.get(key) is not None:
       challenge[key] = dd[key]
 
-  return {
+  body = {
     'dd': challenge,
     'ddCookie': dd['cookie'],
     'iframeData': {'html': document_html, 'url': document_url},
@@ -205,10 +205,14 @@ def solve_request_body(dd, document_html, document_url, proxy, target_url):
       'tlsClientHello': '',
       'userAgent': PROFILE['userAgent'],
     },
-    'proxy': proxy,
     'timeout': TIMEOUT_S * 1000,
     'url': target_url,
   }
+  # Omit the field entirely when going direct — the solver reads its
+  # presence, not its emptiness.
+  if proxy:
+    body['proxy'] = proxy
+  return body
 
 
 def check_prepared_submission(prepared):
@@ -329,28 +333,43 @@ def _is_transport(error):
   )
 
 
+def _transport_reason(configured_proxy, error):
+  """Name the failure the way the run was actually configured."""
+  if not _is_transport(error):
+    return str(error)
+  return 'proxy session failed' if configured_proxy else 'network error'
+
+
 def run(attempt):
   """Read the environment, pin a fresh session per attempt, report.
 
   `attempt` takes (proxy, api_key, solver_url, target_url) and
   returns a (cookie, status) pair, or None when there was no challenge.
+
+  `proxy=` is optional. Unset, `proxy` is None and everything — the
+  challenge, the solve, the submission — goes out from this machine's
+  own address. That is fine as long as it is the *same* address
+  throughout: DataDome binds the clearance cookie to whoever submitted
+  it.
   """
   solver_host = os.environ.get('host')
   configured_proxy = os.environ.get('proxy')
   if not solver_host:
     raise SystemExit('set host= in .env')
-  if not configured_proxy:
-    raise SystemExit('set proxy= in .env')
 
   attempts = int(read_flag('--attempts', '3'))
   target_url = read_flag('--url', DEFAULT_URL)
   solver_url = solver_base_url(solver_host)
   api_key = os.environ.get('api_key')
 
+  if not configured_proxy:
+    log("no proxy= set — going out from this machine's address")
+
   last_error = None
   for i in range(1, attempts + 1):
-    # A fresh session per attempt: a new IP, and a clean slate.
-    proxy, _pinned = pin_session(configured_proxy)
+    # A fresh session per attempt: a new IP, and a clean slate. Nothing
+    # to pin when going direct — every attempt is the same address.
+    proxy = pin_session(configured_proxy)[0] if configured_proxy else None
     try:
       outcome = attempt(proxy, api_key, solver_url, target_url)
       if outcome is None:
@@ -368,12 +387,10 @@ def run(attempt):
       raise SystemExit(RATE_LIMIT_EXIT_CODE) from error
     except Exception as error:  # noqa: BLE001 - report and retry
       last_error = error
-      reason = 'proxy session failed' if _is_transport(error) else str(error)
+      reason = _transport_reason(configured_proxy, error)
       if i < attempts:
         log(f'attempt {i}/{attempts} failed ({reason}) — retrying')
 
-  reason = (
-    'proxy session failed' if _is_transport(last_error) else str(last_error)
-  )
+  reason = _transport_reason(configured_proxy, last_error)
   log(f'RESULT: FAIL - {reason}')
   raise SystemExit(1)

--- a/src/akamai/ca-edd.ts
+++ b/src/akamai/ca-edd.ts
@@ -31,7 +31,6 @@ const log = (msg: string, ...extra: unknown[]): void =>
   console.log(`[${new Date().toISOString()}] ${msg}`, ...extra);
 
 if (!solverHost) throw new Error('set host= in .env');
-if (!proxy) throw new Error('set proxy= in .env');
 if (!username) throw new Error('set username= in .env');
 if (!password) throw new Error('set password= in .env');
 
@@ -50,7 +49,7 @@ const launchOpts: Record<string, unknown> = {
     '--no-default-browser-check',
   ],
   headless: process.argv.includes('--headless'),
-  proxy: toLaunchProxy(proxy),
+  ...(proxy ? { proxy: toLaunchProxy(proxy) } : {}),
 };
 // eslint-disable-next-line security/detect-non-literal-fs-filename
 if (CHROME_PATH && fs.existsSync(CHROME_PATH))
@@ -106,7 +105,7 @@ await applyIdentity(cdp);
 // Solve Akamai
 try {
   await solve(page, {
-    proxy,
+    ...(proxy ? { proxy } : {}),
     ...(solverApiKey ? { solverApiKey } : {}),
     solverUrl,
     url,

--- a/src/akamai/comcast-lightpanda.ts
+++ b/src/akamai/comcast-lightpanda.ts
@@ -63,7 +63,6 @@ const proxy = process.env['proxy'];
 const solverApiKey = process.env['api_key'];
 
 if (!solverHost) throw new Error('set host= in .env');
-if (!proxy) throw new Error('set proxy= in .env');
 
 const solverUrl = solverWsUrl(solverHost, '/akamai/session');
 const timeout = Number(process.env['AKAMAI_TIMEOUT_MS'] ?? 120_000);
@@ -86,7 +85,11 @@ const IDENTITY = {
   'user-agent': PROFILE.userAgent,
 };
 
-const session = await start({ identity: IDENTITY, log, proxy });
+const session = await start({
+  identity: IDENTITY,
+  log,
+  ...(proxy ? { proxy } : {}),
+});
 let exitCode = 0;
 
 process.once('SIGINT', () => {
@@ -113,7 +116,7 @@ try {
     // script — so the defaults (30s/15s) run out before the page settles.
     loadStateTimeout: 60_000,
     navigationTimeout: 90_000,
-    proxy,
+    ...(proxy ? { proxy } : {}),
     ...(solverApiKey ? { solverApiKey } : {}),
     solverUrl,
     timeout,

--- a/src/akamai/comcast.ts
+++ b/src/akamai/comcast.ts
@@ -26,7 +26,6 @@ const log = (msg: string, ...extra: unknown[]): void =>
   console.log(`[${new Date().toISOString()}] ${msg}`, ...extra);
 
 if (!solverHost) throw new Error('set host= in .env');
-if (!proxy) throw new Error('set proxy= in .env');
 
 const solverUrl = solverWsUrl(solverHost, '/akamai/session');
 
@@ -43,7 +42,7 @@ const launchOpts: Record<string, unknown> = {
     '--no-default-browser-check',
   ],
   headless: process.argv.includes('--headless'),
-  proxy: toLaunchProxy(proxy),
+  ...(proxy ? { proxy: toLaunchProxy(proxy) } : {}),
 };
 // eslint-disable-next-line security/detect-non-literal-fs-filename
 if (CHROME_PATH && fs.existsSync(CHROME_PATH))
@@ -99,7 +98,7 @@ await applyIdentity(cdp);
 // Solve Akamai
 try {
   await solve(page, {
-    proxy,
+    ...(proxy ? { proxy } : {}),
     ...(solverApiKey ? { solverApiKey } : {}),
     solverUrl,
     url,

--- a/src/datadome/README.md
+++ b/src/datadome/README.md
@@ -183,7 +183,9 @@ site-by-site results.
 ### picking a client
 
 All three are the same four requests, so copy whichever matches what you
-already use. Two differences worth knowing:
+already use. Every one of them treats `proxy=` as optional — unset, the client
+is built without a proxy and the whole flow goes out from this machine. Two
+differences worth knowing:
 
 - **axios** needs its proxy agent and its cookie jar to be *the same object*.
   Passing `jar` alongside a plain `HttpsProxyAgent` throws `does not support

--- a/src/datadome/grainger-axios.ts
+++ b/src/datadome/grainger-axios.ts
@@ -21,7 +21,7 @@
  */
 import axios from 'axios';
 import { wrapper } from 'axios-cookiejar-support';
-import { createCookieAgent } from 'http-cookie-agent/http';
+import { createCookieAgent, HttpsCookieAgent } from 'http-cookie-agent/http';
 import { HttpsProxyAgent } from 'https-proxy-agent';
 import { CookieJar } from 'tough-cookie';
 
@@ -52,6 +52,9 @@ import { checkRateLimit } from '#src/rate-limit.js';
  * use with other http(s).Agent". Wrapping the proxy agent with
  * `createCookieAgent` gives you one object that both tunnels and stores
  * cookies.
+ *
+ * With no proxy set there is nothing to tunnel, and the package's own
+ * `HttpsCookieAgent` is the same idea over a plain `https.Agent`.
  */
 const HttpsProxyCookieAgent = createCookieAgent(HttpsProxyAgent);
 
@@ -68,7 +71,9 @@ const attempt = async ({
   const jar = new CookieJar();
   const client = wrapper(
     axios.create({
-      httpsAgent: new HttpsProxyCookieAgent(proxy, { cookies: { jar } }),
+      httpsAgent: proxy
+        ? new HttpsProxyCookieAgent(proxy, { cookies: { jar } })
+        : new HttpsCookieAgent({ cookies: { jar } }),
       // Let the agent handle the tunnel; axios's own proxy handling would
       // rewrite the request line and break CONNECT.
       proxy: false,

--- a/src/datadome/grainger-fetch.ts
+++ b/src/datadome/grainger-fetch.ts
@@ -8,7 +8,9 @@
  * browser, and no dependencies at all. Same four requests as
  * grainger-undici.ts; see that file for the flow.
  *
- * Note the `--use-env-proxy` flag. Node's `fetch` takes its proxy from
+ * Note the `--use-env-proxy` flag, which matters only when `proxy=` is set —
+ * with no proxy the script just goes out from this machine and the flag is
+ * harmless either way. Node's `fetch` takes its proxy from
  * `HTTP_PROXY` / `HTTPS_PROXY` rather than a per-request option, and only
  * reads them when started with that flag (or `NODE_USE_ENV_PROXY=1`). This
  * script sets them from `proxy=` in your `.env`, and sets `NO_PROXY` so the
@@ -42,7 +44,10 @@ import {
 } from '#src/datadome/http-utils.js';
 import { checkRateLimit } from '#src/rate-limit.js';
 
+// Only a problem when there is a proxy to ignore. Without `proxy=` this script
+// is meant to go out from your own address, so the flag is beside the point.
 if (
+  process.env['proxy'] &&
   !process.execArgv.includes('--use-env-proxy') &&
   !process.env['NODE_USE_ENV_PROXY']
 ) {
@@ -59,14 +64,16 @@ const attempt = async ({
   solverUrl,
   targetUrl,
 }: Context): Promise<null | Outcome> => {
-  // Node reads these once per request, so setting them here is enough to pin
-  // this attempt's session.
-  process.env['HTTP_PROXY'] = proxy;
-  process.env['HTTPS_PROXY'] = proxy;
-  // Required: the solver is on your own network, and a datacenter proxy will
-  // refuse to tunnel to it. Node matches this against the bare host, so an IP
-  // works as well as a name.
-  process.env['NO_PROXY'] = new URL(solverUrl).hostname;
+  if (proxy) {
+    // Node reads these once per request, so setting them here is enough to pin
+    // this attempt's session.
+    process.env['HTTP_PROXY'] = proxy;
+    process.env['HTTPS_PROXY'] = proxy;
+    // Required: the solver is on your own network, and a datacenter proxy will
+    // refuse to tunnel to it. Node matches this against the bare host, so an
+    // IP works as well as a name.
+    process.env['NO_PROXY'] = new URL(solverUrl).hostname;
+  }
 
   // 1. Trip the challenge.
   log(`GET ${targetUrl}`);

--- a/src/datadome/grainger-lightpanda.ts
+++ b/src/datadome/grainger-lightpanda.ts
@@ -143,7 +143,7 @@ const attempt = async ({
         documents.set(url, body);
       }
     },
-    proxy,
+    ...(proxy ? { proxy } : {}),
   });
   try {
     // 1. Trip the challenge.

--- a/src/datadome/grainger-undici.ts
+++ b/src/datadome/grainger-undici.ts
@@ -25,7 +25,8 @@
  * sending it. See http-utils.ts.
  */
 // undici's `fetch` is the same implementation Node exposes globally, but its
-// types expose `dispatcher`, which is how a per-request proxy is set.
+// types expose `dispatcher`, which is how a per-request proxy is set. Leaving
+// it undefined is how you go direct.
 import { fetch, ProxyAgent } from 'undici';
 
 import {
@@ -54,12 +55,14 @@ const attempt = async ({
   solverUrl,
   targetUrl,
 }: Context): Promise<null | Outcome> => {
-  const dispatcher = new ProxyAgent(proxy);
+  // Spread rather than assigned: an explicit `dispatcher: undefined` is not
+  // the same as leaving the option off, and undici wants it off.
+  const via = proxy ? { dispatcher: new ProxyAgent(proxy) } : {};
 
   // 1. Trip the challenge.
   log(`GET ${targetUrl}`);
   const blocked = await fetch(targetUrl, {
-    dispatcher,
+    ...via,
     headers: navigationHeaders(),
   });
   const blockedHtml = await blocked.text();
@@ -78,7 +81,7 @@ const attempt = async ({
   const documentUrl = challengeDocumentUrl(dd, targetUrl);
   log('GET challenge document');
   const document = await fetch(documentUrl, {
-    dispatcher,
+    ...via,
     headers: documentHeaders(targetUrl),
   });
   const documentHtml = await document.text();
@@ -113,7 +116,7 @@ const attempt = async ({
   log(`${prepared.body ? 'POST' : 'GET'} submission`);
   const submitted = await fetch(prepared.url, {
     ...(prepared.body === undefined ? {} : { body: prepared.body }),
-    dispatcher,
+    ...via,
     headers: submissionHeaders(prepared),
     method: prepared.body === undefined ? 'GET' : 'POST',
   });
@@ -124,7 +127,7 @@ const attempt = async ({
   // Prove it: the request that 403'd should now return the real page.
   log('verifying against the target');
   const verified = await fetch(targetUrl, {
-    dispatcher,
+    ...via,
     headers: { ...navigationHeaders(), cookie: `datadome=${cookie}` },
   });
   const html = await verified.text();

--- a/src/datadome/grainger.ts
+++ b/src/datadome/grainger.ts
@@ -26,13 +26,14 @@ const chromePath = process.env['CHROME_PATH'] || '';
 const browserHoldMs = 30_000;
 
 if (!solverHost) throw new Error('set host= in .env');
-if (!configuredProxy) throw new Error('set proxy= in .env');
 
 const solverUrl = solverBaseUrl(solverHost);
 const log = (msg: string, ...extra: unknown[]): void =>
   console.log(`[${new Date().toISOString()}] ${msg}`, ...extra);
 
-const { url: proxy } = pinSession(configuredProxy);
+// No proxy is a valid setup: the browser and the submission then both go
+// out from this machine, which is all DataDome asks — one address throughout.
+const proxy = configuredProxy ? pinSession(configuredProxy).url : undefined;
 
 const launchOptions: LaunchOptions = {
   args: [
@@ -43,7 +44,7 @@ const launchOptions: LaunchOptions = {
   ],
   headless: process.argv.includes('--headless'),
   ignoreDefaultArgs: ['--enable-automation', '--force-color-profile=srgb'],
-  proxy: toLaunchProxy(proxy),
+  ...(proxy ? { proxy: toLaunchProxy(proxy) } : {}),
 };
 
 // eslint-disable-next-line security/detect-non-literal-fs-filename
@@ -96,7 +97,7 @@ try {
   });
   const page = await context.newPage();
   const result = await solve(page, {
-    proxy,
+    ...(proxy ? { proxy } : {}),
     ...(solverApiKey ? { solverApiKey } : {}),
     solverUrl,
     url,

--- a/src/datadome/http-utils.ts
+++ b/src/datadome/http-utils.ts
@@ -34,7 +34,8 @@ export const TIMEOUT_MS = 120_000;
 
 /** Everything an attempt needs, already resolved from the environment. */
 export type Context = {
-  proxy: string;
+  /** Undefined when `proxy=` is unset: go out from this machine's address. */
+  proxy: string | undefined;
   solverApiKey: string | undefined;
   solverUrl: string;
   targetUrl: string;
@@ -166,7 +167,7 @@ export const solveRequestBody = ({
   dd: DataDomeBlock;
   documentHtml: string;
   documentUrl: string;
-  proxy: string;
+  proxy: string | undefined;
   targetUrl: string;
 }): Record<string, unknown> => ({
   dd: {
@@ -204,7 +205,9 @@ export const solveRequestBody = ({
     tlsClientHello: '',
     userAgent: PROFILE.userAgent,
   },
-  proxy,
+  // Omit the field entirely when going direct — the solver reads its
+  // presence, not its emptiness.
+  ...(proxy ? { proxy } : {}),
   timeout: TIMEOUT_MS,
   url: targetUrl,
 });
@@ -259,8 +262,13 @@ const isTransport = (error: unknown): boolean =>
  * attempt, runs `attempt`, and reports the result the way every other example
  * in this repo does.
  *
- * There is one proxy pool, `proxy`. Each attempt pins a fresh session, so a
- * dead exit node is retried on a new IP rather than failing the run.
+ * `proxy=` is optional. With it, each attempt pins a fresh session, so a dead
+ * exit node is retried on a new IP rather than failing the run. Without it,
+ * everything — the challenge, the solve, the submission — goes out from this
+ * machine's own address, which is a fine way to try the flow from a laptop or
+ * from a box that already egresses where you want it to. The one rule that
+ * survives either way: the clearance cookie is bound to whichever address
+ * submitted it, so browse from the same place you solved from.
  *
  * `--require-challenge` turns "nothing challenged us" into a failure. CI passes
  * it so the smoke gate cannot go green without actually exercising a solve.
@@ -272,21 +280,24 @@ export const run = async (
   const solverHost = process.env['host'];
   const configuredProxy = process.env['proxy'];
   if (!solverHost) throw new Error('set host= in .env');
-  if (!configuredProxy) throw new Error('set proxy= in .env');
 
   const attempts = Number(readFlag('--attempts') ?? 3);
   const targetUrl = readFlag('--url') ?? DEFAULT_URL;
   const solverUrl = solverBaseUrl(solverHost);
   const requireChallenge = process.argv.includes('--require-challenge');
 
-  const label = 'PROXY';
+  const label = configuredProxy ? 'PROXY' : 'DIRECT';
+  if (!configuredProxy) {
+    log("no proxy= set — going out from this machine's address");
+  }
 
   let lastError: unknown;
   let sawNoChallenge = false;
 
   for (let i = 1; i <= attempts; i += 1) {
     // A fresh session per attempt: a new IP, and a clean slate with DataDome.
-    const { url: proxy } = pinSession(configuredProxy);
+    // Nothing to pin when going direct — every attempt is the same address.
+    const proxy = configuredProxy ? pinSession(configuredProxy).url : undefined;
     try {
       const outcome = await attempt({
         proxy,
@@ -326,19 +337,34 @@ export const run = async (
       lastError = error;
       if (isTransport(error)) {
         const more = i < attempts ? ', NOW RETRYING' : '';
-        log(`${label} = DEAD NODE (attempt ${i}/${attempts})${more}`);
+        const what = configuredProxy ? 'DEAD NODE' : 'NETWORK ERROR';
+        log(`${label} = ${what} (attempt ${i}/${attempts})${more}`);
       } else {
         const more = i < attempts ? ' — retrying' : '';
         log(
           `${label} = attempt ${i}/${attempts} failed (${(error as Error).message})${more}`
         );
+        // A captcha solve with no `proxy` in the body currently fails inside
+        // the sandbox, which cannot fetch the captcha's stylesheet asset. All
+        // it says is `HTTP 500 DD solve error`, so name it here.
+        if (
+          !configuredProxy &&
+          /DD solve error/.test((error as Error).message)
+        ) {
+          log(
+            '  hint: DataDome captcha solves currently fail without a proxy — set proxy= in .env'
+          );
+        }
       }
     }
   }
 
   process.exitCode = 1;
-  const reason = isTransport(lastError)
+  const transportReason = configuredProxy
     ? 'proxy session failed'
+    : 'network error';
+  const reason = isTransport(lastError)
+    ? transportReason
     : ((lastError as Error)?.message ??
       (sawNoChallenge ? 'no challenge' : 'unknown'));
   log(`RESULT: FAIL - ${reason}`);

--- a/src/datadome/idealista.ts
+++ b/src/datadome/idealista.ts
@@ -26,13 +26,14 @@ const chromePath = process.env['CHROME_PATH'] || '';
 const browserHoldMs = 30_000;
 
 if (!solverHost) throw new Error('set host= in .env');
-if (!configuredProxy) throw new Error('set proxy= in .env');
 
 const solverUrl = solverBaseUrl(solverHost);
 const log = (msg: string, ...extra: unknown[]): void =>
   console.log(`[${new Date().toISOString()}] ${msg}`, ...extra);
 
-const { url: proxy } = pinSession(configuredProxy);
+// No proxy is a valid setup: the browser and the submission then both go
+// out from this machine, which is all DataDome asks — one address throughout.
+const proxy = configuredProxy ? pinSession(configuredProxy).url : undefined;
 
 const launchOptions: LaunchOptions = {
   args: [
@@ -43,7 +44,7 @@ const launchOptions: LaunchOptions = {
   ],
   headless: process.argv.includes('--headless'),
   ignoreDefaultArgs: ['--enable-automation', '--force-color-profile=srgb'],
-  proxy: toLaunchProxy(proxy),
+  ...(proxy ? { proxy: toLaunchProxy(proxy) } : {}),
 };
 
 // eslint-disable-next-line security/detect-non-literal-fs-filename
@@ -96,7 +97,7 @@ try {
   });
   const page = await context.newPage();
   const result = await solve(page, {
-    proxy,
+    ...(proxy ? { proxy } : {}),
     ...(solverApiKey ? { solverApiKey } : {}),
     solverUrl,
     url,

--- a/src/datadome/solver.ts
+++ b/src/datadome/solver.ts
@@ -1289,7 +1289,9 @@ async function callSolver(
       method: 'POST',
     },
     timeout
-  );
+  ).catch((error: unknown) => {
+    throw withProxylessHint(error, proxy);
+  });
   const result = validateSolverResult(raw, challenge.dd.rt);
   const referer = new URL(result.referer);
   const expectedPath = challenge.dd.rt === 'c' ? '/captcha/' : '/interstitial/';
@@ -1838,4 +1840,18 @@ async function waitForCookieRotation(
     await raceFatal(delay(50), fatal);
   }
   throw new Error('The target datadome cookie did not rotate');
+}
+
+/**
+ * A captcha solve with no `proxy` in the body currently fails inside the
+ * sandbox — it cannot fetch the captcha's own stylesheet asset — and surfaces
+ * as a bare `HTTP 500 DD solve error`, which names nothing. Name it here.
+ */
+function withProxylessHint(error: unknown, proxy: string | undefined): Error {
+  const err = asError(error);
+  if (proxy || !/DD solve error|dd\.solve\.failed/.test(err.message)) {
+    return err;
+  }
+  err.message = `${err.message} — no proxy= is set, and DataDome captcha solves currently fail without one`;
+  return err;
 }


### PR DESCRIPTION
## what

`proxy=` is now optional in every example.

Nothing in either vendor's flow needs a proxy specifically — the requirement is that the challenge, the solve and the submission all leave from **one** address, and this machine is one address. Unset `proxy=` and each client is built without one (no `ProxyAgent`, no `HttpsProxyAgent`, no `HTTP_PROXY`, no Playwright launch proxy, `via=()` in `dev-resources/curl`), the `/dd/solve` body omits the field rather than sending an empty one, and no session is pinned — there is nothing to rotate when every attempt is the same IP.

Runs say which mode they are in: `DIRECT` instead of `PROXY`, and `network error` instead of `proxy session failed`.

## verification

Against the live solver:

- **with `proxy=`** — full smoke suite passes, plus all three Python clients. Unchanged from before this branch; `grainger-lightpanda` stays advisory and still fails intermittently, as it did already.
- **without `proxy=`** — Akamai (`comcast.ts`) passes; the DataDome interstitial path passes on undici, axios, built-in fetch, `dev-resources/curl`, requests, httpx and urllib. 
- `npm run lint`, `npm run build`, `node --test`, `ruff check` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Srubs938Puw63X7tK9KjTq