### PR TITLE
fix: point idealista back at the homepage, and un-advisory it

### DIFF
--- a/dev-resources/smoke.js
+++ b/dev-resources/smoke.js
@@ -22,23 +22,6 @@ const LOADTEST_PATH = path.join(PROJECT_ROOT, 'src/loadtest.ts');
 //
 // `advisory` runs a script and reports it without letting it fail the suite.
 //
-// idealista is advisory because there is nothing left in this repo to fix. It
-// serves a captcha, we solve it, the carrier GET returns 200 — and then the
-// next document it hands back is not a second captcha but DataDome's terminal
-// block page: "Se ha detectado un uso indebido", the blocked IP printed on it,
-// and a support form. 28KB against the captcha's 580KB, with no
-// `captcha__element` in it at all. The round loop reports that as a recurrent
-// challenge, which is a fair description of what it saw and a misleading one
-// of what happened: the solve was not rejected for being wrong, the address
-// was blocked after making it.
-//
-// So it is not a missing captcha variant and not a client bug. Two things
-// point at the browser interaction itself being scored: it happens from a
-// residential address and from CI runners alike, and the HTTP clients — which
-// never execute DataDome's script — solve the same target and are cleared.
-// That is solver work, tracked separately, not something a change here
-// reaches.
-//
 // grainger-lightpanda was advisory on the theory that DataDome refuses the
 // cookie a solve from a Lightpanda page earns — 11 attempts across two runs,
 // no successes, where the same commit verified locally. That note named its
@@ -59,7 +42,7 @@ const SCRIPTS = [
   { script: 'src/datadome/grainger-fetch', useEnvProxy: true },
   { headless: true, script: 'src/datadome/grainger' },
   { advisory: true, script: 'src/datadome/grainger-lightpanda' },
-  { advisory: true, headless: true, script: 'src/datadome/idealista' },
+  { headless: true, script: 'src/datadome/idealista' },
   { headless: true, script: 'src/akamai/comcast' },
   { script: 'src/akamai/comcast-lightpanda' },
   { headless: true, script: 'src/akamai/ca-edd' },

--- a/src/datadome/idealista.ts
+++ b/src/datadome/idealista.ts
@@ -9,10 +9,20 @@
  * and frequently turns it into a captcha (`rt:"c"`) rather than accepting the
  * first submission, which is the `i -> c` chain the round loop in solver.ts
  * exists for. Run this one after changing anything in that loop.
+ *
+ * The homepage is the target on purpose. This example was briefly repointed at
+ * a Madrid search-results page, and that is a different test: DataDome guards
+ * a listings page — the thing scrapers actually want — far harder than a
+ * homepage, and answers with a captcha on first contact rather than an
+ * interstitial. Solve it and the next document is a block page, so the round
+ * loop reports a recurrent challenge and the `i -> c` chain never runs at all.
+ * Same code, same address, minutes apart: the homepage escalated and solved,
+ * the search page was blocked. A harder target is worth having, but as its own
+ * example rather than in place of the escalation one.
  */
 import { runBrowserTarget } from '#src/datadome/browser-target.js';
 
 await runBrowserTarget({
   name: 'idealista',
-  url: 'https://www.idealista.com/venta-viviendas/madrid-madrid/',
+  url: 'https://www.idealista.com/',
 });


### PR DESCRIPTION
The red idealista check was a URL change, not a solver problem. This reverts it and takes idealista back off advisory.

## What happened

`2ccebac "refactor: update urls"` repointed the example:

```diff
-  url: 'https://www.idealista.com/',
+  url: 'https://www.idealista.com/venta-viviendas/madrid-madrid/',
```

That is a different test, not a harder version of the same one. DataDome guards a listings page — the thing scrapers actually want — far harder than a homepage. On the search page it answers with a **captcha on first contact** instead of an interstitial, and once that is solved the next document is not a second captcha but its **block page**. The round loop reports a recurrent challenge, and the `i -> c` chain this example exists to exercise never runs at all.

## Evidence

Same code, same machine, same address, minutes apart:

```
search page   captcha (round 1, c)                -> blocked
homepage      interstitial (round 1, i)
              captcha (round 2, i -> c)           -> SUCCESS   x3
```

CI history agrees exactly:

| date | url | first challenge | outcome |
|---|---|---|---|
| Aug 22 | homepage | interstitial → captcha | **SUCCESS** |
| Aug 24 | homepage | interstitial → captcha | FAIL (banned CI proxy IP — unrelated) |
| Aug 25 16:10 | **search page** | **captcha** | FAIL |
| Aug 26 | search page | captcha | FAIL |

The flip lands exactly on `2ccebac`.

## What it rules out

- **Not IP reputation.** CI runners get a fresh address every run and still got captcha-first on the search page.
- **Not the solve being detected.** grainger's browser path uses the identical slider machinery and passes. We were being classified before touching the slider — the captcha arrives on first contact.
- **Not geometry.** With stylesheets now supplied, the solver resolves slider geometry structurally and logs no fallback warning.

So the earlier note attributing this to solver-side interaction scoring was wrong, and is removed. idealista goes back to blocking, where a real regression stays visible.

## Follow-up worth having

A harder target is still worth covering — as its own example rather than in place of the escalation one. The same repointing was applied to `alaska.ts` (→ an entity search) and `etsy.ts` (→ a listing). Neither is in the smoke suite, so neither has been measured; they may be in the same position.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Radn7tL8iC8iEUZk6kY7qX